### PR TITLE
Add daily puzzle entries for 2026-04-22 through 2026-04-29 and fix small typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1146,7 +1146,7 @@
     {
       releaseDate: "2026-04-15",
       questions: [
-       "Ten  minus two = ?",
+       "Ten minus two = ?",
        "Solve: 4x + 1 = 245",
        "Compute: 5^3 + 150",
        "Compute: 4652 × 2",
@@ -1266,7 +1266,7 @@
     {
       releaseDate: "2026-04-21",
       questions: [
-       "Geometry: How many points (non-collinear) determine a plane?",
+        "Geometry: How many points (non-collinear) determine a plane?",
        "Compute: 100 − 42 = ?",
        "Compute: 358 × 2 = ?",
        "Compute: 28,206 ÷ 3 = ?",
@@ -1282,6 +1282,166 @@
       difficultyRating: 3.3,
       hintText: "3, 58, 716, 9402.",
       code: [9, 0, 6, 2, 1]
+    },
+    {
+      releaseDate: "2026-04-22",
+      questions: [
+        "Algebra: Solve 3x = 18",
+        "Exponent: 3^4 = ?",
+        "Compute: 5550 ÷ 6 = ?",
+        "Compute: 3517 × 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [8, 1],
+        [9, 2, 5],
+        [7, 0, 3, 4],
+        [5, 2, 3, 4, 7]
+      ],
+      difficultyRating: 4.6,
+      hintText: "6, 81, 925, 7034.",
+      code: [5, 2, 3, 4, 7]
+    },
+    {
+      releaseDate: "2026-04-23",
+      questions: [
+        "Trivia: How many strings does a violin have?",
+        "Compute: 60 + 11 = ?",
+        "Compute: 463 × 2 = ?",
+        "Compute: 7016 ÷ 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [7, 1],
+        [9, 2, 6],
+        [3, 5, 0, 8],
+        [3, 2, 6, 0, 8]
+      ],
+      difficultyRating: 2.6,
+      hintText: "4, 71, 926, 3508.",
+      code: [3, 2, 6, 0, 8]
+    },
+    {
+      releaseDate: "2026-04-24",
+      questions: [
+        "Trivia: How many wheels does a standard bicycle have?",
+        "Compute: 17 × 5 = ?",
+        "Compute: 10,000 - 9284 = ?",
+        "Compute: 9284 + 20 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [8, 5],
+        [7, 1, 6],
+        [9, 3, 0, 4],
+        [7, 5, 6, 4, 0]
+      ],
+      difficultyRating: 2.2,
+      hintText: "2, 85, 716, 9304.",
+      code: [7, 5, 6, 4, 0]
+    },
+    {
+      releaseDate: "2026-04-25",
+      questions: [
+        "Compute: 8 - 3 + (-5) = ?",
+        "Compute: 100 − 14 = ?",
+        "Compute: 59 × 5 = ?",
+        "Solve: 2865 + x = 9999, x = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [0],
+        [8, 6],
+        [2, 9, 5],
+        [7, 1, 3, 4],
+        [0, 6, 5, 9, 4]
+      ],
+      difficultyRating: 4.7,
+      hintText: "0, 86, 295, 7134.",
+      code: [0, 6, 5, 9, 4]
+    },
+    {
+      releaseDate: "2026-04-26",
+      questions: [
+        "Compute: 3 × 3 ÷ 9 = ?",
+        "Compute: 26 × 3 = ?",
+        "Compute: 17 × 25 = ?",
+        "Compute: 3201 × 3 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [7, 8],
+        [4, 2, 5],
+        [9, 6, 0, 3],
+        [2, 8, 5, 3, 4]
+      ],
+      difficultyRating: 3.1,
+      hintText: "1, 78, 425, 9603.",
+      code: [2, 8, 5, 3, 4]
+    },
+    {
+      releaseDate: "2026-04-27",
+      questions: [
+        "Probability: How many even outcomes on a fair die?",
+        "Evaluate: 7x, when x = 2?",
+        "Compute: 43 × 20 = ?",
+        "Compute: 5518 ÷ 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [1, 4],
+        [8, 6, 0],
+        [2, 7, 5, 9],
+        [5, 4, 0, 9, 1]
+      ],
+      difficultyRating: 2.6,
+      hintText: "3, 14, 860, 2759.",
+      code: [5, 4, 0, 9, 1]
+    },
+    {
+      releaseDate: "2026-04-28",
+      questions: [
+        "Round 2.8 to the nearest whole number",
+        "For y = 4x + 7, the y-intercept as a point (x, y).",
+        "Compute: 97 + 97",
+        "Compute: 573 × 5",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [0, 7],
+        [1, 9, 4],
+        [2, 8, 6, 5],
+        [2, 9, 6, 5, 8]
+      ],
+      difficultyRating: 2.8,
+      hintText: "3, 07, 194, 2865.",
+      code: [2, 9, 6, 5, 8]
+    },
+    {
+      releaseDate: "2026-04-29",
+      questions: [
+        "Compute: √36",
+        "Solve: 7x = 98",
+        "Compute: 46 × 20 = ?",
+        "Compute: 7358 × 9 ÷ 9 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [1, 4],
+        [9, 2, 0],
+        [7, 3, 5, 8],
+        [5, 2, 0, 8, 9]
+      ],
+      difficultyRating: 3.7,
+      hintText: "6, 14, 920, 7358.",
+      code: [5, 2, 0, 8, 9]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Populate the in-app puzzle schedule with the provided daily puzzles so they will appear in the game queue on the intended dates.
- Keep the schedule chronological and complete by interpreting the ambiguous `4.9` input as `2026-04-29`.
- Fix a small text typo found in an existing prompt to improve polish.

### Description
- Added eight new `puzzleSchedule` entries for `2026-04-22` through `2026-04-29` to `index.html`, each including `questions`, `correctAnswers`, `hintText`, `code`, and `difficultyRating` fields.
- Ensured the new entries match the existing payload shape used by the schedule loader so they will be picked up by `getActivePuzzle()` unchanged.
- Corrected the spacing typo in the prompt string from `"Ten  minus two = ?"` to `"Ten minus two = ?"`.
- Interpreted the provided `4.9` label as `4/29` and added that puzzle as `releaseDate: "2026-04-29"` to keep the array chronological.

### Testing
- Searched the updated file for the new `releaseDate` entries using `rg` to confirm all dates `2026-04-22` through `2026-04-29` are present, which succeeded.
- Inspected the `index.html` changes with `sed`/`nl` to verify the inserted puzzle objects and formatting, which showed the expected entries.
- Applied the patch successfully and verified the file was updated without syntax errors by reviewing the post-change `index.html` snippet, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e00fcd4ba0832d9946096bee41241b)