### PR TITLE
Add puzzle schedule entries for Apr 30–May 6, 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -1442,6 +1442,146 @@
       difficultyRating: 3.7,
       hintText: "6, 14, 920, 7358.",
       code: [5, 2, 0, 8, 9]
+    },
+    {
+      releaseDate: "2026-04-30",
+      questions: [
+        "Solve: 2x + 1 = 11",
+        "Compute: 136 ÷ 2",
+        "Compute: 31 × 7",
+        "Compute: 10,000 − 957",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [6, 8],
+        [2, 1, 7],
+        [9, 0, 4, 3],
+        [9, 0, 7, 6, 3]
+      ],
+      difficultyRating: 4.4,
+      hintText: "5, 68, 217, 9043.",
+      code: [9, 0, 7, 6, 3]
+    },
+    {
+      releaseDate: "2026-05-01",
+      questions: [
+        "Compute: √64",
+        "Compute: 2^4",
+        "Compute: 352 × 2",
+        "Compute: 8805 ÷ 3",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [1, 6],
+        [7, 0, 4],
+        [2, 9, 3, 5],
+        [1, 6, 4, 5, 7]
+      ],
+      difficultyRating: 2.1,
+      hintText: "8, 16, 704, 2935.",
+      code: [1, 6, 4, 5, 7]
+    },
+    {
+      releaseDate: "2026-05-02",
+      questions: [
+        "One-third of 12",
+        "Compute: a fourth of a circle (in degrees)",
+        "Evaluate: If f(x) = 52x + 1, find f(5)",
+        "Compute: 3679 × 2",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [9, 0],
+        [2, 6, 1],
+        [7, 3, 5, 8],
+        [9, 0, 2, 8, 1]
+      ],
+      difficultyRating: 3.3,
+      hintText: "4, 90, 261, 7358.",
+      code: [9, 0, 2, 8, 1]
+    },
+    {
+      releaseDate: "2026-05-03",
+      questions: [
+        "Probability: How many odd outcomes are on a fair die?",
+        "Geometry: Area of a triangle with base 26 and height 4",
+        "Compute: 17 × 54",
+        "Compute: 12094 ÷ 2",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [5, 2],
+        [9, 1, 8],
+        [6, 0, 4, 7],
+        [9, 2, 8, 0, 7]
+      ],
+      difficultyRating: 4.1,
+      hintText: "3, 52, 918, 6047.",
+      code: [9, 2, 8, 0, 7]
+    },
+    {
+      releaseDate: "2026-05-04",
+      questions: [
+        "Geometry: How many endpoints does a line segment have?",
+        "Compute: 94 ÷ 2",
+        "Compute: 27^2 + 86",
+        "Compute: 3195 × 2",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [4, 7],
+        [8, 1, 5],
+        [6, 3, 9, 0],
+        [8, 7, 5, 0, 6]
+      ],
+      difficultyRating: 3.8,
+      hintText: "2, 47, 815, 6390.",
+      code: [8, 7, 5, 0, 6]
+    },
+    {
+      releaseDate: "2026-05-05",
+      questions: [
+        "Compute: 5 ÷ 5 ?",
+        "Compute: |9824 - 9898|",
+        "Compute: 484 × 2",
+        "Compute: 1528 + 777",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [7, 4],
+        [9, 6, 8],
+        [2, 3, 0, 5],
+        [9, 6, 8, 1, 5]
+      ],
+      difficultyRating: 3.9,
+      hintText: "1, 74, 968, 2305.",
+      code: [9, 6, 8, 1, 5]
+    },
+    {
+      releaseDate: "2026-05-06",
+      questions: [
+        "How many faces does a cube have?",
+        "Compute: 58 ÷ 2",
+        "Compute: 377 × 2",
+        "Compute: 921 + 320 + 139",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [2, 9],
+        [7, 5, 4],
+        [1, 3, 8, 0],
+        [7, 3, 4, 2, 0]
+      ],
+      difficultyRating: 1.9,
+      hintText: "6, 29, 754, 1380.",
+      code: [7, 3, 4, 2, 0]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Extend the daily puzzle calendar with the next week of content so the app will serve puzzles for `2026-04-30` through `2026-05-06`. 
- Include each day's questions, `correctAnswers`, `difficultyRating`, `hintText`, and final `code` so the front-end can render the new puzzles. 

### Description
- Added seven new objects to the `puzzleSchedule` array in `index.html` for release dates `2026-04-30` through `2026-05-06`, each containing `releaseDate`, `questions`, `correctAnswers`, `difficultyRating`, `hintText`, and `code`. 
- Normalized one prompt text to `"Compute: 94 ÷ 2"` to match the provided expected answer. 
- This is a content-only change with no modifications to application logic or runtime behavior. 
- The existing schedule sorting (`.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))`) is left unchanged so new entries integrate automatically. 

### Testing
- Verified the diff with `git diff -- index.html` and searched for the inserted release dates with `rg -n "2026-04-30|2026-05-06|2026-05-0[1-5]" index.html`, both commands returned the expected results. 
- Committed the change with `git commit` which completed successfully. 
- Inspected the updated file region with `nl`/`sed` to confirm the new schedule entries were inserted as intended. 
- No automated unit or integration tests were added or required for this content-only update; all smoke checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea75016cc0832d83d69f229ba798f9)