### PR TITLE
Remove April puzzles and add May 7–13 puzzles; fix wording and hints

### DIFF
--- a/index.html
+++ b/index.html
@@ -906,606 +906,6 @@
 
    const puzzleSchedule = [
     {
-      releaseDate: "2026-04-01",
-      questions: [
-       "Compute: 0^0 (often believed to equal)",
-       "Compute: 3|1+2+3+4....+∞|^(-1)",
-       "Why was 6 afraid of 7? Because…",
-       "19 years from now?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [1],
-       [3, 6],
-       [7, 8, 9],
-       [2, 0, 4, 5],
-       [8, 6, 4, 5, 1]
-      ],
-      difficultyRating: 3.1,
-      hintText: "1, 36, 789, 2045.",
-      code: [8, 6, 4, 5, 1]
-    },
-    {
-      releaseDate: "2026-04-02",
-      questions: [
-       "Compute: √4",
-       "Compute: 100 − 3",
-       "Compute: 64 × 10",
-       "Compute: 4074 ÷ 3",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [2],
-       [9, 7],
-       [6, 4, 0],
-       [1, 3, 5, 8],
-       [9, 7, 0, 8, 5]
-      ],
-      difficultyRating: 1.8,
-      hintText: "2, 97, 640, 1358.",
-      code: [9, 7, 0, 8, 5]
-    },
-    {
-      releaseDate: "2026-04-03",
-      questions: [
-       "Compute: Half of 10",
-       "Compute: 28 ÷ 2",
-       "Compute: 12% of 8000",
-       "Compute: 1832 × 4",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [5],
-       [1, 4],
-       [9, 6, 0],
-       [7, 3, 2, 8],
-       [5, 4, 0, 1, 8]
-      ],
-      difficultyRating: 3.1,
-      hintText: "5, 14, 960, 7328.",
-      code: [5, 4, 0, 1, 8]
-    },
-    {
-      releaseDate: "2026-04-04",
-      questions: [
-       "How many dimensions are in 3D space?",
-       "Compute: 43 × 2",
-       "Compute: 97 + 97",
-       "Compute: 44,444 - 37,194",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [3],
-       [8, 6],
-       [1, 9, 4],
-       [7, 2, 5, 0],
-       [3, 6, 4, 2, 0]
-      ],
-      difficultyRating: 2.6,
-      hintText: "3, 86, 194, 7250.",
-      code: [3, 6, 4, 2, 0]
-    },
-    {
-      releaseDate: "2026-04-05",
-      questions: [
-       "Compute: ½ × 2",
-       "Compute: 29 × 2",
-       "Compute: 363 × 2",
-       "Compute: 4652 × 2",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [1],
-       [5, 8],
-       [7, 2, 6],
-       [9, 3, 0, 4],
-       [6, 8, 0, 4, 5]
-      ],
-      difficultyRating: 2.2,
-      hintText: "1, 58, 726, 9304.",
-      code: [6, 8, 0, 4, 5]
-    },
-    {
-      releaseDate: "2026-04-06",
-      questions: [
-       "168 hours is how many days?",
-       "Compute: 58 ÷ 2",
-       "Compute: 1248 - 832",
-       "Compute: 4175 × 2",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [7],
-       [2, 9],
-       [4, 1, 6],
-       [8, 3, 5, 0],
-       [4, 3, 6, 1, 0]
-      ],
-      difficultyRating: 2.9,
-      hintText: "7, 29, 416, 8350.",
-      code: [4, 3, 6, 1, 0]
-    },
-    {
-      releaseDate: "2026-04-07",
-      questions: [
-       "How many suits are in a standard deck of cards?",
-       "Solve: 3x = 183",
-       "How many minutes are in 13 hours?",
-       "Compute: 1847 × 5",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [4],
-       [6, 1],
-       [7, 8, 0],
-       [9, 2, 3, 5],
-       [6, 3, 0, 5, 1]
-      ],
-      difficultyRating: 3.7,
-      hintText: "4, 61, 780, 9235.",
-      code: [6, 3, 0, 5, 1]
-    },
-    {
-      releaseDate: "2026-04-08",
-      questions: [
-       "Geometry: How many endpoints does a line segment have?",
-       "Compute: 100 − 21 = ?",
-       "Geometry: Area of a triangle with base 48 and height 7 = ?",
-       "Compute: 1527 × 2 = ?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [2],
-       [7, 9],
-       [1, 6, 8],
-       [3, 0, 5, 4],
-       [7, 9, 8, 0, 4]
-      ],
-      difficultyRating: 3.6,
-      hintText: "2, 79, 168, 3054.",
-      code: [7, 9, 8, 0, 4]
-    },
-    {
-      releaseDate: "2026-04-09",
-      questions: [
-       "Trivia: How many vowels are in 'AEIOU'?",
-       "Compute: 122 ÷ 2 = ?",
-       "Compute: 678 + 292 = ?",
-       "Compute: 298 × 8 = ?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [5],
-       [6, 1],
-       [9, 7, 0],
-       [2, 3, 8, 4],
-       [6, 1, 0, 4, 8]
-      ],
-      difficultyRating: 2.4,
-      hintText: "5, 61, 970, 2384.",
-      code: [6, 1, 0, 4, 8]
-    },
-    {
-      releaseDate: "2026-04-10",
-      questions: [
-       "How many squares are on a 3×3 grid?",
-       "Compute: 6 × 7 = ?",
-       "Compute: 19 × 40 = ?",
-       "Compute: 367 × 5 = ?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [9],
-       [4, 2],
-       [7, 6, 0],
-       [1, 8, 3, 5],
-       [9, 2, 0, 1, 5]
-      ],
-      difficultyRating: 2.8,
-      hintText: "9, 42, 760, 1835.",
-      code: [9, 2, 0, 1, 5]
-    },
-    {
-      releaseDate: "2026-04-11",
-      questions: [
-       "Compute: 2^0 = ?",
-       "Compute: 1280 ÷ 16 = ?",
-       "One revolution around the sun in days (rounded)",
-       "Compute: 4637 × 2 = ?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [1],
-       [8, 0],
-       [3, 6, 5],
-       [9, 2, 7, 4],
-       [8, 6, 0, 4, 7]
-      ],
-      difficultyRating: 4.3,
-      hintText: "1, 80, 365, 9274.",
-      code: [8, 6, 0, 4, 7]
-    },
-    {
-      releaseDate: "2026-04-12",
-      questions: [
-       "Trivia: How many continents are there (traditional count)?",
-       "Compute: 5 × 7 = ?",
-       "Compute: 1000 - 98 = ?",
-       "Compute: 8420 ÷ 5 = ?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [7],
-       [3, 5],
-       [9, 0, 2],
-       [1, 6, 8, 4],
-       [1, 6, 2, 4, 8]
-      ],
-      difficultyRating: 1.9,
-      hintText: "7, 35, 902, 1684.",
-      code: [1, 6, 2, 4, 8]
-    },
-    {
-      releaseDate: "2026-04-13",
-      questions: [
-       "Algebra: How many real solutions does x^2 + 1 = 0 have?",
-       "Compute: 39 × 2 = ?",
-       "Today's date? (_ /__)",
-       "Compute: 5318 ÷ 2 = ?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [0],
-       [7, 8],
-       [4, 1, 3],
-       [2, 6, 5, 9],
-       [7, 8, 3, 4, 9]
-      ],
-      difficultyRating: 3.8,
-      hintText: "0, 78, 314, 2659.",
-      code: [7, 8, 3, 4, 9]
-    },
-    {
-      releaseDate: "2026-04-14",
-      questions: [
-       "Trivia/CS: How many bits are in a byte?",
-       "Compute: 4^2 = ?",
-       "Compute: 352 × 2 = ?",
-       "Compute: 8805 ÷ 3 = ?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [8],
-       [1, 6],
-       [7, 0, 4],
-       [2, 9, 3, 5],
-       [8, 6, 4, 0, 5]
-      ],
-      difficultyRating: 4.7,
-      hintText: "8, 16, 704, 2935.",
-      code: [8, 6, 4, 0, 5]
-    },
-    {
-      releaseDate: "2026-04-15",
-      questions: [
-       "Ten minus two = ?",
-       "Solve: 4x + 1 = 245",
-       "Compute: 5^3 + 150",
-       "Compute: 4652 × 2",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [8],
-       [6, 1],
-       [2, 7, 5],
-       [9, 3, 0, 4],
-       [8, 1, 5, 7, 4]
-      ],
-      difficultyRating: 4.3,
-      hintText: "8, 61, 275, 9304.",
-      code: [8, 1, 5, 7, 4]
-    },
-    {
-      releaseDate: "2026-04-16",
-      questions: [
-       "Slope of the line through (0,0) and (1,3) = ?",
-       "For y = -2x + 7, the y-intercept as a point (x,y).",
-       "Compute: 200 − 6",
-       "Compute: 1257 × 5",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [3],
-       [0, 7],
-       [1, 9, 4],
-       [6, 2, 8, 5],
-       [6, 7, 4, 5, 2]
-      ],
-      difficultyRating: 3.1,
-      hintText: "3, 07, 194, 6285.",
-      code: [6, 7, 4, 5, 2]
-    },
-    {
-      releaseDate: "2026-04-17",
-      questions: [
-       "How many Olympic rings are there?",
-       "Compute: 140 ÷ 5 =?",
-       "Compute: 52 × 8 = ?",
-       "Compute: 3093 + 4000 = ?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [5],
-       [2, 8],
-       [4, 1, 6],
-       [7, 0, 9, 3],
-       [5, 1, 6, 9, 3]
-      ],
-      difficultyRating: 2.2,
-      hintText: "5, 28, 416, 7093.",
-      code: [5, 1, 6, 9, 3]
-    },
-    {
-      releaseDate: "2026-04-18",
-      questions: [
-       "Algebra: How many real solutions does x^2 + 4 = 0 have?",
-       "Compute: 100 − 14 = ?",
-       "Compute: 1770 ÷ 6 = ?",
-       "Compute: 3567 × 2 = ?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [0],
-       [8, 6],
-       [2, 9, 5],
-       [7, 1, 3, 4],
-       [8, 1, 5, 7, 4]
-      ],
-      difficultyRating: 4.0,
-      hintText: "0, 86, 295, 7134.",
-      code: [8, 1, 5, 7, 4]
-    },
-    {
-      releaseDate: "2026-04-19",
-      questions: [
-       "(234 + 430 -938)^0 ?",
-       "Compute: 7×7 + 4",
-       "Compute: 0.85 × 800 (enter a whole number)",
-       "Compute: 3962 × 2",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [1],
-       [5, 3],
-       [6, 8, 0],
-       [7, 9, 2, 4],
-       [5, 3, 0, 6, 4]
-      ],
-      difficultyRating: 2.7,
-      hintText: "1, 53, 680, 7924.",
-      code: [5, 3, 0, 6, 4]
-    },
-    {
-      releaseDate: "2026-04-20",
-      questions: [
-       "April is this numbered month?",
-       "Today is this day of the month?",
-       "Compute: 13 by 13 = ?",
-       "Compute: 7777 - 420 + 1 = ?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [4],
-       [2, 0],
-       [1, 6, 9],
-       [7, 3, 5, 8],
-       [6, 0, 9, 8, 1]
-      ],
-      difficultyRating: 4.1,
-      hintText: "4, 20, 169, 7358.",
-      code: [6, 0, 9, 8, 1]
-    },
-    {
-      releaseDate: "2026-04-21",
-      questions: [
-        "Geometry: How many points (non-collinear) determine a plane?",
-       "Compute: 100 − 42 = ?",
-       "Compute: 358 × 2 = ?",
-       "Compute: 28,206 ÷ 3 = ?",
-       "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-       [3],
-       [5, 8],
-       [7, 1, 6],
-       [9, 4, 0, 2],
-       [9, 0, 6, 2, 1]
-      ],
-      difficultyRating: 3.3,
-      hintText: "3, 58, 716, 9402.",
-      code: [9, 0, 6, 2, 1]
-    },
-    {
-      releaseDate: "2026-04-22",
-      questions: [
-        "Algebra: Solve 3x = 18",
-        "Exponent: 3^4 = ?",
-        "Compute: 5550 ÷ 6 = ?",
-        "Compute: 3517 × 2 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [6],
-        [8, 1],
-        [9, 2, 5],
-        [7, 0, 3, 4],
-        [5, 2, 3, 4, 7]
-      ],
-      difficultyRating: 4.6,
-      hintText: "6, 81, 925, 7034.",
-      code: [5, 2, 3, 4, 7]
-    },
-    {
-      releaseDate: "2026-04-23",
-      questions: [
-        "Trivia: How many strings does a violin have?",
-        "Compute: 60 + 11 = ?",
-        "Compute: 463 × 2 = ?",
-        "Compute: 7016 ÷ 2 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [4],
-        [7, 1],
-        [9, 2, 6],
-        [3, 5, 0, 8],
-        [3, 2, 6, 0, 8]
-      ],
-      difficultyRating: 2.6,
-      hintText: "4, 71, 926, 3508.",
-      code: [3, 2, 6, 0, 8]
-    },
-    {
-      releaseDate: "2026-04-24",
-      questions: [
-        "Trivia: How many wheels does a standard bicycle have?",
-        "Compute: 17 × 5 = ?",
-        "Compute: 10,000 - 9284 = ?",
-        "Compute: 9284 + 20 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [2],
-        [8, 5],
-        [7, 1, 6],
-        [9, 3, 0, 4],
-        [7, 5, 6, 4, 0]
-      ],
-      difficultyRating: 2.2,
-      hintText: "2, 85, 716, 9304.",
-      code: [7, 5, 6, 4, 0]
-    },
-    {
-      releaseDate: "2026-04-25",
-      questions: [
-        "Compute: 8 - 3 + (-5) = ?",
-        "Compute: 100 − 14 = ?",
-        "Compute: 59 × 5 = ?",
-        "Solve: 2865 + x = 9999, x = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [0],
-        [8, 6],
-        [2, 9, 5],
-        [7, 1, 3, 4],
-        [0, 6, 5, 9, 4]
-      ],
-      difficultyRating: 4.7,
-      hintText: "0, 86, 295, 7134.",
-      code: [0, 6, 5, 9, 4]
-    },
-    {
-      releaseDate: "2026-04-26",
-      questions: [
-        "Compute: 3 × 3 ÷ 9 = ?",
-        "Compute: 26 × 3 = ?",
-        "Compute: 17 × 25 = ?",
-        "Compute: 3201 × 3 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [1],
-        [7, 8],
-        [4, 2, 5],
-        [9, 6, 0, 3],
-        [2, 8, 5, 3, 4]
-      ],
-      difficultyRating: 3.1,
-      hintText: "1, 78, 425, 9603.",
-      code: [2, 8, 5, 3, 4]
-    },
-    {
-      releaseDate: "2026-04-27",
-      questions: [
-        "Probability: How many even outcomes on a fair die?",
-        "Evaluate: 7x, when x = 2?",
-        "Compute: 43 × 20 = ?",
-        "Compute: 5518 ÷ 2 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [3],
-        [1, 4],
-        [8, 6, 0],
-        [2, 7, 5, 9],
-        [5, 4, 0, 9, 1]
-      ],
-      difficultyRating: 2.6,
-      hintText: "3, 14, 860, 2759.",
-      code: [5, 4, 0, 9, 1]
-    },
-    {
-      releaseDate: "2026-04-28",
-      questions: [
-        "Round 2.8 to the nearest whole number",
-        "For y = 4x + 7, the y-intercept as a point (x, y).",
-        "Compute: 97 + 97",
-        "Compute: 573 × 5",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [3],
-        [0, 7],
-        [1, 9, 4],
-        [2, 8, 6, 5],
-        [2, 9, 6, 5, 8]
-      ],
-      difficultyRating: 2.8,
-      hintText: "3, 07, 194, 2865.",
-      code: [2, 9, 6, 5, 8]
-    },
-    {
-      releaseDate: "2026-04-29",
-      questions: [
-        "Compute: √36",
-        "Solve: 7x = 98",
-        "Compute: 46 × 20 = ?",
-        "Compute: 7358 × 9 ÷ 9 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [6],
-        [1, 4],
-        [9, 2, 0],
-        [7, 3, 5, 8],
-        [5, 2, 0, 8, 9]
-      ],
-      difficultyRating: 3.7,
-      hintText: "6, 14, 920, 7358.",
-      code: [5, 2, 0, 8, 9]
-    },
-    {
-      releaseDate: "2026-04-30",
-      questions: [
-        "Solve: 2x + 1 = 11",
-        "Compute: 136 ÷ 2",
-        "Compute: 31 × 7",
-        "Compute: 10,000 − 957",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [5],
-        [6, 8],
-        [2, 1, 7],
-        [9, 0, 4, 3],
-        [9, 0, 7, 6, 3]
-      ],
-      difficultyRating: 4.4,
-      hintText: "5, 68, 217, 9043.",
-      code: [9, 0, 7, 6, 3]
-    },
-    {
       releaseDate: "2026-05-01",
       questions: [
         "Compute: √64",
@@ -1588,7 +988,7 @@
     {
       releaseDate: "2026-05-05",
       questions: [
-        "Compute: 5 ÷ 5 ?",
+        "Compute: 5 ÷ 5 = ?",
         "Compute: |9824 - 9898|",
         "Compute: 484 × 2",
         "Compute: 1528 + 777",
@@ -1624,6 +1024,146 @@
       difficultyRating: 1.9,
       hintText: "6, 29, 754, 1380.",
       code: [7, 3, 4, 2, 0]
+    },
+    {
+      releaseDate: "2026-05-07",
+      questions: [
+        "Combinatorics: How many ways can you choose 1 item from 8? (8C1)",
+        "Compute: 6^2 + 15 = ?",
+        "Compute: 29^2 − 48 = ?",
+        "Compute: 3000 × 2 + 17 × 12 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [5, 1],
+        [7, 9, 3],
+        [6, 2, 0, 4],
+        [5, 1, 3, 0, 4]
+      ],
+      difficultyRating: 4.3,
+      hintText: "8, 51, 793, 6204.",
+      code: [5, 1, 3, 0, 4]
+    },
+    {
+      releaseDate: "2026-05-08",
+      questions: [
+        "Geometry: How many sides does a hexagon have?",
+        "Compute: 20% of 70 = ?",
+        "Compute: 3608 ÷ 4 = ?",
+        "Compute: 3679 × 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [1, 4],
+        [9, 0, 2],
+        [7, 3, 5, 8],
+        [7, 4, 2, 0, 8]
+      ],
+      difficultyRating: 3.8,
+      hintText: "6, 14, 902, 7358.",
+      code: [7, 4, 2, 0, 8]
+    },
+    {
+      releaseDate: "2026-05-09",
+      questions: [
+        "Trivia: How many letters are in the word 'AUDIO'?",
+        "Compute: 14 × 2 = ?",
+        "Compute: 520 − 104 = ?",
+        "Compute: 7000 + 93 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [2, 8],
+        [4, 1, 6],
+        [7, 0, 9, 3],
+        [7, 8, 6, 2, 3]
+      ],
+      difficultyRating: 2.3,
+      hintText: "5, 28, 416, 7093.",
+      code: [7, 8, 6, 2, 3]
+    },
+    {
+      releaseDate: "2026-05-10",
+      questions: [
+        "Logic: How many solutions does x = x + 1 have?",
+        "Compute: 37 × 2 = ?",
+        "Solve the system for (x, y, z): y = 3z − 1, z = 3, and x = y − 7.",
+        "Compute: 5912 ÷ 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [0],
+        [7, 4],
+        [1, 8, 3],
+        [2, 9, 5, 6],
+        [0, 4, 3, 8, 6]
+      ],
+      difficultyRating: 3.4,
+      hintText: "0, 74, 183, 2956.",
+      code: [0, 4, 3, 8, 6]
+    },
+    {
+      releaseDate: "2026-05-11",
+      questions: [
+        "Trivia: What is nitrogen's atomic number?",
+        "Compute: 70 − 35 = ?",
+        "Compute: 451 × 2 = ?",
+        "Compute: 8420 ÷ 5 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [7],
+        [3, 5],
+        [9, 0, 2],
+        [1, 6, 8, 4],
+        [3, 5, 2, 7, 4]
+      ],
+      difficultyRating: 2.3,
+      hintText: "7, 35, 902, 1684.",
+      code: [3, 5, 2, 7, 4]
+    },
+    {
+      releaseDate: "2026-05-12",
+      questions: [
+        "Compute: √36 = ?",
+        "Compute: 512 - 421 = ?",
+        "Compute: 5^3 + 80 = ?",
+        "Compute: 83 × 90 + 13 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [9, 1],
+        [2, 0, 5],
+        [7, 4, 8, 3],
+        [9, 1, 5, 3, 6]
+      ],
+      difficultyRating: 3.7,
+      hintText: "6, 91, 205, 7483.",
+      code: [9, 1, 5, 3, 6]
+    },
+    {
+      releaseDate: "2026-05-13",
+      questions: [
+        "7 times what equals 21?",
+        "If y = 4x + 7, find the y-intercept as a point (x, y).",
+        "Compute: 97 + 97 = ?",
+        "Compute: 573 × 5 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [0, 7],
+        [1, 9, 4],
+        [2, 8, 6, 5],
+        [2, 7, 4, 5, 1]
+      ],
+      difficultyRating: 2.8,
+      hintText: "3, 07, 194, 2865.",
+      code: [2, 7, 4, 5, 1]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Remove all April 2026 entries from the in-page `puzzleSchedule` so the schedule starts at `2026-05-01` and only includes the provided May puzzles. 
- Add a new week of puzzles (May 7–May 13, 2026) using the supplied questions, answers, hints, codes, and difficulty ratings. 
- Clean up small grammar/formatting issues and data inconsistencies in the newly added content so prompts and hints are consistent and human-readable.

### Description
- Deleted all `2026-04-*` puzzle objects and updated the `puzzleSchedule` array in `index.html` to begin at `2026-05-01` and include new entries through `2026-05-13`.
- Inserted May 7–13 puzzle objects with the provided `questions`, `correctAnswers`, `hintText`, `difficultyRating`, and `code` values so they integrate with the existing schedule and `applyPuzzleData` logic.
- Corrected wording and punctuation in several prompts (for example the combinatorics prompt now reads "How many ways can you choose 1 item from 8? (8C1)", the nitrogen trivia reads "What is nitrogen's atomic number?", and `"Compute: 5 ÷ 5 = ?"` includes the equals sign).
- Fixed data consistency issues including replacing an incorrect third-answer hint on May 10 so the `hintText` matches the solution (`183`), and ensured `hintText` is used consistently (replacing `hintText_` where applicable).

### Testing
- Verified there are no remaining April entries with `rg -n "releaseDate: \"2026-04" index.html`, which returned no matches and confirmed April removals. 
- Confirmed May 1–May 13 entries are present with `rg -n "releaseDate: \"2026-05-(0[1-9]|1[0-3])\"" index.html`, which returned matches for the new range. 
- Attempted an HTML syntax check with `node -c index.html` which failed because Node's syntax checker does not accept `.html` files in this environment, so no HTML parse error was produced or detected by that command.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42904adac832daf2ae8a92d2b77e7)