### PR TITLE
Add May 14-20 puzzle schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -1164,6 +1164,146 @@
       difficultyRating: 2.8,
       hintText: "3, 07, 194, 2865.",
       code: [2, 7, 4, 5, 1]
+    },
+    {
+      releaseDate: "2026-05-14",
+      questions: [
+        "Solve: x + 12 = 17",
+        "Solve: 4x = 272",
+        "Compute: 6^3 + 1",
+        "Compute: 4521 × 2 + 1",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [6, 8],
+        [2, 1, 7],
+        [9, 0, 4, 3],
+        [6, 8, 7, 1, 3]
+      ],
+      difficultyRating: 4.2,
+      hintText: "5, 68, 217, 9043.",
+      code: [6, 8, 7, 1, 3]
+    },
+    {
+      releaseDate: "2026-05-15",
+      questions: [
+        "Geometry: How many vertices does a cube have?",
+        "Solve: 3x + 2 = 44",
+        "Compute: 2232 ÷ 8",
+        "Compute: 127 × 50",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [1, 4],
+        [2, 7, 9],
+        [6, 3, 5, 0],
+        [8, 4, 9, 6, 0]
+      ],
+      difficultyRating: 3.5,
+      hintText: "8, 14, 279, 6350.",
+      code: [8, 4, 9, 6, 0]
+    },
+    {
+      releaseDate: "2026-05-16",
+      questions: [
+        "All even integers are divisible by this number",
+        "Compute: 94 ÷ 2",
+        "Compute: 5^4 + 190",
+        "Compute: 2130 × 3",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [4, 7],
+        [8, 1, 5],
+        [6, 3, 9, 0],
+        [6, 7, 9, 0, 5]
+      ],
+      difficultyRating: 2.0,
+      hintText: "2, 47, 815, 6390.",
+      code: [6, 7, 9, 0, 5]
+    },
+    {
+      releaseDate: "2026-05-17",
+      questions: [
+        "Solve: 3x = 27",
+        "Compute: 1716 ÷ 33",
+        "Compute: 29 × 14",
+        "Compute: 2017 − 630",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [9],
+        [5, 2],
+        [4, 0, 6],
+        [1, 3, 8, 7],
+        [1, 2, 6, 0, 7]
+      ],
+      difficultyRating: 4.7,
+      hintText: "9, 52, 406, 1387.",
+      code: [1, 2, 6, 0, 7]
+    },
+    {
+      releaseDate: "2026-05-18",
+      questions: [
+        "Solve: 2x + 5 = 11",
+        "Geometry: A triangle with b = 10 and h = 14",
+        "Compute: 200 − 6",
+        "Compute: 3129 × 2",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [7, 0],
+        [1, 9, 4],
+        [6, 2, 5, 8],
+        [7, 5, 4, 8, 0]
+      ],
+      difficultyRating: 1.6,
+      hintText: "3, 70, 194, 6258.",
+      code: [7, 5, 4, 8, 0]
+    },
+    {
+      releaseDate: "2026-05-19",
+      questions: [
+        "Solve: x^2 - 36 = 0 (x > 0)",
+        "Compute: 7 × 13",
+        "Sum: 33 + 44 + 28 + 45 + 55",
+        "Compute: 7500 − 17",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [9, 1],
+        [2, 0, 5],
+        [7, 4, 8, 3],
+        [6, 4, 5, 2, 3]
+      ],
+      difficultyRating: 4.1,
+      hintText: "6, 91, 205, 7483.",
+      code: [6, 4, 5, 2, 3]
+    },
+    {
+      releaseDate: "2026-05-20",
+      questions: [
+        "Find the slope: 8x - 2y = 3",
+        "Solve the system (a,b): a - b = -7, a + b = 11",
+        "Compute: 850 − 149",
+        "Compute: 43265 ÷ 5",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [2, 9],
+        [7, 0, 1],
+        [8, 6, 5, 3],
+        [2, 1, 5, 3, 9]
+      ],
+      difficultyRating: 4.5,
+      hintText: "4, 29, 701, 8653.",
+      code: [2, 1, 5, 3, 9]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Queue the next week's puzzles so the game can release daily puzzles for May 14 through May 20, 2026 as part of the existing schedule.

### Description
- Added seven puzzle objects (releaseDate `2026-05-14` → `2026-05-20`) to the `puzzleSchedule` array in `index.html`, each with `questions`, `correctAnswers`, `difficultyRating`, `hintText`, and `code` fields.
- The new entries follow the same data shape as existing puzzles and rely on the existing `.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))` to preserve activation order.
- No other logic or UI code was changed; this PR only extends the schedule data used by the game.

### Testing
- Executed a Node validation script (`node - <<'NODE' ... NODE`) that verified each added puzzle exists, has five questions, five answer rows, a five-digit `code`, and that the final answer row matches the `code`, and the script reported success.
- No automated tests failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd1ac880f8832d92b716f231454b6d)