### PR TITLE
Add daily puzzle queue entries for May 21–27, 2026

### DIFF
--- a/index.html
+++ b/index.html
@@ -1304,6 +1304,146 @@
       difficultyRating: 4.5,
       hintText: "4, 29, 701, 8653.",
       code: [2, 1, 5, 3, 9]
+    },
+    {
+      releaseDate: "2026-05-21",
+      questions: [
+        "Algebra: Solve 4x + 2 = 26",
+        "Compute: 12 × 7 ÷ 6 = ?",
+        "Compute: 451 × 2 = ?",
+        "Compute: 22,260 - 14902 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [1, 4],
+        [9, 0, 2],
+        [7, 3, 5, 8],
+        [7, 4, 2, 0, 8]
+      ],
+      difficultyRating: 4.1,
+      hintText: "6, 14, 902, 7358.",
+      code: [7, 4, 2, 0, 8]
+    },
+    {
+      releaseDate: "2026-05-22",
+      questions: [
+        "Graphing: How many sections are on a coordinate plane?",
+        "Solve: 9x = 648",
+        "Percent: 12% of 8000 = ?",
+        "Compute: 679 × 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [7, 2],
+        [9, 6, 0],
+        [1, 3, 5, 8],
+        [6, 3, 0, 8, 1]
+      ],
+      difficultyRating: 2.4,
+      hintText: "4, 72, 960, 1358.",
+      code: [6, 3, 0, 8, 1]
+    },
+    {
+      releaseDate: "2026-05-23",
+      questions: [
+        "Solve for x: y/y = x, y does not equal 0 ?",
+        "Compute: 37 × 2 = ?",
+        "Solve: z = 3, y = 3z − 1, and y = x + 8. Enter xyz.",
+        "Compute: 5912 ÷ 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [7, 4],
+        [0, 8, 3],
+        [2, 9, 5, 6],
+        [1, 9, 3, 0, 6]
+      ],
+      difficultyRating: 3.7,
+      hintText: "1, 74, 083, 2956.",
+      code: [1, 9, 3, 0, 6]
+    },
+    {
+      releaseDate: "2026-05-24",
+      questions: [
+        "Trivia: How many players are on the field for one baseball team?",
+        "Compute: 21 + 31 = ?",
+        "Compute: 203 × 2 = ?",
+        "Compute: 1500 − 113 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [9],
+        [5, 2],
+        [4, 0, 6],
+        [1, 3, 8, 7],
+        [1, 8, 6, 7, 2]
+      ],
+      difficultyRating: 2.9,
+      hintText: "9, 52, 406, 1387.",
+      code: [1, 8, 6, 7, 2]
+    },
+    {
+      releaseDate: "2026-05-25",
+      questions: [
+        "Probability: How many outcomes are odd on a fair die?",
+        "Coordinate geometry: y-intercept of y = 4x + 7 as a point (x,y).",
+        "Compute: 97 + 97 = ?",
+        "Compute: 573 × 5 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [0, 7],
+        [1, 9, 4],
+        [2, 8, 6, 5],
+        [9, 7, 4, 5, 0]
+      ],
+      difficultyRating: 2.6,
+      hintText: "3, 07, 194, 2865.",
+      code: [9, 7, 4, 5, 0]
+    },
+    {
+      releaseDate: "2026-05-26",
+      questions: [
+        "Compute: 2 × 2 = ?",
+        "Compute: 29 × 2 = ?",
+        "Compute: 82 × 5 = ?",
+        "Compute: 4688 × 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [5, 8],
+        [4, 1, 0],
+        [9, 3, 7, 6],
+        [5, 3, 7, 6, 4]
+      ],
+      difficultyRating: 3.1,
+      hintText: "4, 58, 410, 9376.",
+      code: [5, 3, 7, 6, 4]
+    },
+    {
+      releaseDate: "2026-05-27",
+      questions: [
+        "Compute: 64 ÷ 8 = ?",
+        "Compute: 936 ÷ 18 = ?",
+        "Compute: 2103 ÷ 3 = ?",
+        "Compute: 7892 ÷ 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [5, 2],
+        [7, 0, 1],
+        [3, 9, 4, 6],
+        [5, 4, 1, 6, 0]
+      ],
+      difficultyRating: 3.1,
+      hintText: "8, 52, 701, 3946.",
+      code: [5, 4, 1, 6, 0]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Populate the upcoming daily puzzle queue with content for 2026-05-21 through 2026-05-27 so the app has scheduled puzzles for those dates. 
- Use the provided question sets, expected digit answers, hint text, difficulty ratings, and final codes for each day.

### Description
- Inserted seven new puzzle objects into the `puzzleSchedule` array in `index.html`, one for each date from `2026-05-21` to `2026-05-27`, each containing `releaseDate`, `questions`, `correctAnswers`, `difficultyRating`, `hintText`, and `code` fields.
- Kept the schedule array sorted and compatible with the existing `.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))` behavior.
- No gameplay or scheduling logic was modified; this change only adds content entries.

### Testing
- Inspected the modified file region with `nl -ba index.html | sed -n '1270,1465p'` to confirm the seven new entries appear in the expected location and format (succeeded).
- Verified the schedule remains a properly-formed array of objects and the added entries match the provided payload structure (succeeded).
- Confirmed the change does not alter existing logic around `applyPuzzleData` or release scheduling by checking nearby code that consumes `puzzleSchedule` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca4a17780832d96255f9b57bf5fe7)