### PR TITLE
Add puzzle schedule entries for 2026-05-28 through 2026-06-03

### DIFF
--- a/index.html
+++ b/index.html
@@ -1444,6 +1444,146 @@
       difficultyRating: 3.1,
       hintText: "8, 52, 701, 3946.",
       code: [5, 4, 1, 6, 0]
+    },
+    {
+      releaseDate: "2026-05-28",
+      questions: [
+        "Science: How many DNA bases are there (A,C,G,T)?",
+        "Compute: 9^2 − 10 = ?",
+        "Compute: 2778 ÷ 3 = ?",
+        "Compute: 1754 × 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [7, 1],
+        [9, 2, 6],
+        [3, 5, 0, 8],
+        [7, 5, 6, 2, 8]
+      ],
+      difficultyRating: 3.4,
+      hintText: "4, 71, 926, 3508.",
+      code: [7, 5, 6, 2, 8]
+    },
+    {
+      releaseDate: "2026-05-29",
+      questions: [
+        "Conversion: 72 inches is this many feet?",
+        "Compute: 145 × 0.2 = ?",
+        "Compute: 2^7 + 30 = ?",
+        "Compute: 10,000 − 2,957 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [2, 9],
+        [1, 5, 8],
+        [7, 0, 4, 3],
+        [4, 5, 8, 3, 2]
+      ],
+      difficultyRating: 4.2,
+      hintText: "6, 29, 158, 7043.",
+      code: [4, 5, 8, 3, 2]
+    },
+    {
+      releaseDate: "2026-05-30",
+      questions: [
+        "Sports: How many strikes make a strikeout?",
+        "Compute: 43 × 2 = ?",
+        "Compute: 97 + 97 = ?",
+        "Compute: (10,000 - 5,301) - 1,994 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [8, 6],
+        [1, 9, 4],
+        [2, 7, 0, 5],
+        [2, 6, 0, 5, 9]
+      ],
+      difficultyRating: 2.6,
+      hintText: "3, 86, 194, 2705.",
+      code: [2, 6, 0, 5, 9]
+    },
+    {
+      releaseDate: "2026-05-31",
+      questions: [
+        "Algebra: How many real solutions does x^2 = 0 have?",
+        "Compute: 94 ÷ 2 = ?",
+        "Percent: 8% of 12,000 = ?",
+        "Compute: 951 × 3 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [4, 7],
+        [9, 6, 0],
+        [2, 8, 5, 3],
+        [9, 7, 0, 1, 3]
+      ],
+      difficultyRating: 3.8,
+      hintText: "1, 47, 960, 2853.",
+      code: [9, 7, 0, 1, 3]
+    },
+    {
+      releaseDate: "2026-06-01",
+      questions: [
+        "Baseball: How many innings are in a regulation game?",
+        "Solve: 5x = 150",
+        "Compute: 98 + 163 + 303 + 187 = ?",
+        "Compute: 2341 × 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [9],
+        [3, 0],
+        [7, 5, 1],
+        [4, 6, 8, 2],
+        [9, 0, 8, 3, 2]
+      ],
+      difficultyRating: 3.9,
+      hintText: "9, 30, 751, 4682.",
+      code: [9, 0, 8, 3, 2]
+    },
+    {
+      releaseDate: "2026-06-02",
+      questions: [
+        "Sides on a pentagon?",
+        "Combinatorics: How many ways to choose 2 items from 8? (8C2)",
+        "Compute: 4998 ÷ 7 = ?",
+        "Compute: 52 × 180 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [2, 8],
+        [7, 1, 4],
+        [9, 3, 6, 0],
+        [9, 8, 6, 0, 5]
+      ],
+      difficultyRating: 3.0,
+      hintText: "5, 28, 714, 9360.",
+      code: [9, 8, 6, 0, 5]
+    },
+    {
+      releaseDate: "2026-06-03",
+      questions: [
+        "Algebra: How many real solutions does x^2 - 4 = 0 have?",
+        "Compute: 100 - 16 = ?",
+        "Solve the system (x,y,z): x = 7, x - 1 = z, x - y = z",
+        "Compute: 4526 × 2 + 1 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [8, 4],
+        [7, 1, 6],
+        [9, 0, 5, 3],
+        [5, 4, 6, 3, 7]
+      ],
+      difficultyRating: 4.5,
+      hintText: "2, 84, 716, 9053.",
+      code: [5, 4, 6, 3, 7]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Prepare and schedule the next week of daily puzzles so the app can serve new content from 2026-05-28 through 2026-06-03.
- Keep the existing `puzzleSchedule` format and sorting behavior so release logic and front-end rendering remain unchanged.

### Description
- Appended seven new puzzle objects to the `puzzleSchedule` array in `index.html` with `releaseDate`, `questions`, `correctAnswers`, `difficultyRating`, `hintText`, and `code` for each day (2026-05-28 → 2026-06-03). 
- Maintained the established object format and left the `.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))` call to preserve chronological ordering.
- Normalized the formatting of one arithmetic prompt to use `10,000` in the 2026-05-30 entry while preserving the provided answer keys.
- No behavioral or logic changes were made outside of the schedule data insertion in `index.html`.

### Testing
- Verified the new release dates are present using `rg -n "releaseDate: \"2026-05-2[8-9]|2026-05-3[0-1]|2026-06-0[1-3]" index.html`, and the search returned the expected entries.
- Inspected the inserted region with `nl -ba index.html | sed -n '1438,1605p'` to confirm the full seven-object block was added and properly formatted.
- Confirmed the `puzzleSchedule` array still ends with the `.sort(...)` call and that no other parts of `index.html` were modified.
- All automated verification steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b62cdd94832d8002b92d20211040)