### PR TITLE
Add June 4–10, 2026 puzzles to schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -1584,6 +1584,146 @@
       difficultyRating: 4.5,
       hintText: "2, 84, 716, 9053.",
       code: [5, 4, 6, 3, 7]
+    },
+    {
+      releaseDate: "2026-06-04",
+      questions: [
+        "Trivia: How many strings does a standard guitar have?",
+        "Geometry: Area of a 9 by 9 square = ?",
+        "Compute: 37 × 25 = ?",
+        "Compute: 14068 ÷ 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [8, 1],
+        [9, 2, 5],
+        [7, 0, 3, 4],
+        [7, 1, 5, 3, 4]
+      ],
+      difficultyRating: 3.9,
+      hintText: "6, 81, 925, 7034.",
+      code: [7, 1, 5, 3, 4]
+    },
+    {
+      releaseDate: "2026-06-05",
+      questions: [
+        "Trivia: How many suits are in a standard deck of cards?",
+        "Compute: 7^2 + 22 = ?",
+        "Compute: 4630 ÷ 5 = ?",
+        "Compute: 1754 × 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [7, 1],
+        [9, 2, 6],
+        [3, 5, 0, 8],
+        [9, 1, 6, 5, 8]
+      ],
+      difficultyRating: 3.1,
+      hintText: "4, 71, 926, 3508.",
+      code: [9, 1, 6, 5, 8]
+    },
+    {
+      releaseDate: "2026-06-06",
+      questions: [
+        "Algebra: How many real roots does x(x−1)(x+1)=0 have?",
+        "Coordinate geometry: y-intercept of y = −3x + 4 as (x,y)",
+        "Compute: 97 + 97 + 3 = ?",
+        "Compute: 573 × 5 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [0, 4],
+        [1, 9, 7],
+        [2, 8, 6, 5],
+        [2, 7, 6, 5, 8]
+      ],
+      difficultyRating: 4.4,
+      hintText: "3, 04, 197, 2865.",
+      code: [2, 7, 6, 5, 8]
+    },
+    {
+      releaseDate: "2026-06-07",
+      questions: [
+        "Trivia: How many Platonic solids are there?",
+        "Percent: 70% of 40 = ?",
+        "Compute: 26 × 16 = ?",
+        "Compute: 6800 + 293 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [2, 8],
+        [4, 1, 6],
+        [7, 0, 9, 3],
+        [5, 8, 9, 7, 3]
+      ],
+      difficultyRating: 2.7,
+      hintText: "5, 28, 416, 7093.",
+      code: [5, 8, 9, 7, 3]
+    },
+    {
+      releaseDate: "2026-06-08",
+      questions: [
+        "Compute: 0.25 × 8 = ?",
+        "Compute: 17 × 5 = ?",
+        "Compute: 358 × 2 = ?",
+        "Compute: 4652 × 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [8, 5],
+        [7, 1, 6],
+        [9, 3, 0, 4],
+        [9, 5, 6, 4, 1]
+      ],
+      difficultyRating: 3.3,
+      hintText: "2, 85, 716, 9304.",
+      code: [9, 5, 6, 4, 1]
+    },
+    {
+      releaseDate: "2026-06-09",
+      questions: [
+        "Trivia: How many innings are in a regulation baseball game?",
+        "Evaluate: 23x, x = 2",
+        "Solve for y: 2y = 540",
+        "Compute: 277 × 5 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [9],
+        [4, 6],
+        [2, 7, 0],
+        [1, 3, 8, 5],
+        [9, 7, 0, 4, 5]
+      ],
+      difficultyRating: 4.2,
+      hintText: "9, 46, 270, 1385.",
+      code: [9, 7, 0, 4, 5]
+    },
+    {
+      releaseDate: "2026-06-10",
+      questions: [
+        "Combinatorics: How many ways to choose 0 items from 7? (7C0)",
+        "Compute: 7^2 + 4 = ?",
+        "Percent: 85% of 800 = ?",
+        "Compute: 8000 − 76 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [5, 3],
+        [6, 8, 0],
+        [7, 9, 2, 4],
+        [7, 9, 0, 3, 4]
+      ],
+      difficultyRating: 2.9,
+      hintText: "1, 53, 680, 7924.",
+      code: [7, 9, 0, 3, 4]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Add the upcoming week's puzzles (June 4–10, 2026) into the daily puzzle schedule so they will be served on their release dates.
- Ensure each puzzle includes question text, per-question digit arrays, hint text, difficulty rating, and the final 5-digit code.
- Preserve existing May puzzles in place until the month completes, with the intended policy to remove the prior month’s puzzles once that month has finished.

### Description
- Added seven new puzzle entries for `2026-06-04` through `2026-06-10` to `index.html` under the `puzzleSchedule` array, including `questions`, `correctAnswers`, `hintText`, `difficultyRating`, and `code` fields.
- Normalized two small wording/formatting items while adding content: changed “suit types” to “suits” and spaced `97 + 97 + 3` for readability.
- Kept the schedule sorted by `releaseDate` so the new entries integrate with existing puzzles.

### Testing
- Ran a parsing/consistency validation that checks unique `releaseDate` values, five questions per puzzle, five answer rows per puzzle, expected answer array lengths, `code` matching the final answer row, and that the first four answers use digits `0–9` exactly once, and all checks passed using a `node` validation script.
- Executed arithmetic and trivia checks for the new June 4–10 puzzles (e.g. `9*9 === 81`, `37*25 === 925`, `14068/2 === 7034`, etc.) with a small `node` script and all checks succeeded.
- Confirmed the `puzzleSchedule` still sorts correctly and that the additions appear in `index.html` without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18997148bc832d9cc504be8ada697c)