### PR TITLE
Add June 11–17 puzzle queue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1724,6 +1724,146 @@
       difficultyRating: 2.9,
       hintText: "1, 53, 680, 7924.",
       code: [7, 9, 0, 3, 4]
+    },
+    {
+      releaseDate: "2026-06-11",
+      questions: [
+        "Algebra: Solve 3x = 18",
+        "Exponent: Compute 3^4",
+        "Solve for a,b,c: a = 2b + c, c - b = 3,c = 5",
+        "Computation: 3517 × 2",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [8, 1],
+        [9, 2, 5],
+        [7, 0, 3, 4],
+        [8, 1, 5, 3, 4]
+      ],
+      difficultyRating: 4.7,
+      hintText: "6, 81, 925, 7034.",
+      code: [8, 1, 5, 3, 4]
+    },
+    {
+      releaseDate: "2026-06-12",
+      questions: [
+        "Geometry: How many faces does a tetrahedron have?",
+        "Compute: 100 − 29",
+        "Compute: 2778 ÷ 3",
+        "Compute: 1754 × 2",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [7, 1],
+        [9, 2, 6],
+        [3, 5, 0, 8],
+        [5, 2, 6, 8, 4]
+      ],
+      difficultyRating: 2.8,
+      hintText: "4, 71, 926, 3508.",
+      code: [5, 2, 6, 8, 4]
+    },
+    {
+      releaseDate: "2026-06-13",
+      questions: [
+        "Probability: In 4 coin flips, the expected number of heads is? ",
+        "Algebra: Solve 5x = 425",
+        "Compute: 358 × 2",
+        "Compute: 6130 + 3214 - 40",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [8, 5],
+        [7, 1, 6],
+        [9, 3, 0, 4],
+        [8, 5, 0, 4, 3]
+      ],
+      difficultyRating: 3.1,
+      hintText: "2, 85, 716, 9304.",
+      code: [8, 5, 0, 4, 3]
+    },
+    {
+      releaseDate: "2026-06-14",
+      questions: [
+        "Solve: 3x = 9",
+        "Compute: 7 × 10",
+        "Compute: 54 + 52 + 44 + 44",
+        "Compute: 9999 - 3741 ",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [7, 0],
+        [1, 9, 4],
+        [6, 2, 5, 8],
+        [6, 2, 4, 5, 8]
+      ],
+      difficultyRating: 2.6,
+      hintText: "3, 70, 194, 6258.",
+      code: [6, 2, 4, 5, 8]
+    },
+    {
+      releaseDate: "2026-06-15",
+      questions: [
+        "Logic: 23 + 56 = 79, 1 = true or 0 = false",
+        "Compute: 7 ÷ 20 × 100",
+        "Discount: If an item is 15% off $800, how much is it?",
+        "Money: Change from $100 if the purchase cost $20.76 (no decimal)",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [3, 5],
+        [6, 8, 0],
+        [7, 9, 2, 4],
+        [2, 9, 0, 4, 1]
+      ],
+      difficultyRating: 4.4,
+      hintText: "1, 35, 680, 7924.",
+      code: [2, 9, 0, 4, 1]
+    },
+    {
+      releaseDate: "2026-06-16",
+      questions: [
+        "Compute: 936 ÷ 104",
+        "Compute: 21 + 31",
+        "Compute: 203 × 2",
+        "Compute: 1500 − 113",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [9],
+        [5, 2],
+        [4, 0, 6],
+        [1, 3, 8, 7],
+        [5, 0, 8, 1, 7]
+      ],
+      difficultyRating: 3.9,
+      hintText: "9, 52, 406, 1387.",
+      code: [5, 0, 8, 1, 7]
+    },
+    {
+      releaseDate: "2026-06-17",
+      questions: [
+        "Geometry: How many sides does a regular pentagon have?",
+        "Geometry: Perimeter of a 9 by 5 rectangle",
+        "Geometry: Area of a rectangle with a length = 17 and width = 42",
+        "Geometry: 26 times around a circle in degrees (1 rotation = 360°)",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [2, 8],
+        [7, 1, 4],
+        [9, 3, 6, 0],
+        [5, 8, 4, 7, 0]
+      ],
+      difficultyRating: 3.6,
+      hintText: "5, 28, 714, 9360.",
+      code: [5, 8, 4, 7, 0]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Populate the daily puzzle schedule with entries for 2026-06-11 through 2026-06-17 so the game has content queued for those dates.
- Ensure each entry contains the full puzzle payload (questions, `correctAnswers`, `difficultyRating`, `hintText`, and `code`) for runtime consumption.

### Description
- Added seven new puzzle objects (June 11–17, 2026) to the `puzzleSchedule` array in `index.html` with their questions, answer digit arrays, difficulty ratings, hint text, and final code.
- Kept the existing `puzzleSchedule` sort by `releaseDate` so releases remain chronological after insertion.
- Changes are persisted and committed to the repository (file modified: `index.html`).

### Testing
- Ran `node --check /tmp/godle-main.js` on the extracted script content and it succeeded to validate JavaScript syntax within the script body.
- Ran a `python3` presence check that verified each new `releaseDate` string exists in `index.html` and it succeeded.
- Ran `git diff --check` and a commit; the repository commit completed successfully, while `node --check index.html` was attempted and reported failure because Node does not accept `.html` files (expected limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20924eae90832da4e46c1980366d79)