### PR TITLE
Add June 18–24, 2026 puzzles to schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -1262,6 +1262,146 @@
       difficultyRating: 3.6,
       hintText: "5, 28, 714, 9360.",
       code: [5, 8, 4, 7, 0]
+    },
+    {
+      releaseDate: "2026-06-18",
+      questions: [
+        "Geometry: How many sides does a tetrahedron have?",
+        "Division: 497 ÷ 7 = ?",
+        "Subtraction: 1000 − 74 = ?",
+        "Subtraction: 1703 + 1805 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [7, 1],
+        [9, 2, 6],
+        [3, 5, 0, 8],
+        [3, 1, 6, 0, 8]
+      ],
+      difficultyRating: 3.0,
+      hintText: "4, 71, 926, 3508.",
+      code: [3, 1, 6, 0, 8]
+    },
+    {
+      releaseDate: "2026-06-19",
+      questions: [
+        "Probabailty: How many outcomes when flipping a fair coin?",
+        "Percent: 17 out of 20 as a percentage = ?(%)",
+        "Subtraction: 800 − 84 = ?",
+        "Multiplication: 4652 × 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [8, 5],
+        [7, 1, 6],
+        [9, 3, 0, 4],
+        [8, 1, 5, 4, 6]
+      ],
+      difficultyRating: 2.6,
+      hintText: "2, 85, 716, 9304.",
+      code: [8, 1, 5, 4, 6]
+    },
+    {
+      releaseDate: "2026-06-20",
+      questions: [
+        "Word problem: The product of two and three?",
+        "Algebra: Solve 7x = 637",
+        "Compute: 5^3 + 80 = ?",
+        "Subtraction: 8000 − 517 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [9, 1],
+        [2, 0, 5],
+        [7, 4, 8, 3],
+        [5, 4, 8, 3, 6]
+      ],
+      difficultyRating: 3.8,
+      hintText: "6, 91, 205, 7483.",
+      code: [5, 4, 8, 3, 6]
+    },
+    {
+      releaseDate: "2026-06-21",
+      questions: [
+        "Science: How many primary colors of light are there (RGB)?",
+        "Line: y-intercept of y = 2x + 4 as a point (x,y). ",
+        "Compute: 2^7 + 69 = ?",
+        "Multiplication: 573 × 5 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [0, 4],
+        [1, 9, 7],
+        [2, 8, 6, 5],
+        [1, 4, 7, 5, 2]
+      ],
+      difficultyRating: 3.2,
+      hintText: "3, 04, 197, 2865.",
+      code: [1, 4, 7, 5, 2]
+    },
+    {
+      releaseDate: "2026-06-22",
+      questions: [
+        "Trivia: Cats are said to have how many lives?",
+        "Trivia: How many cards are in a standard deck? (w/o Jokers)",
+        "Multiplication: 29 × 14 = ?",
+        "Subtraction: 2000 − 613 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [9],
+        [5, 2],
+        [4, 0, 6],
+        [1, 3, 8, 7],
+        [0, 3, 6, 7, 9]
+      ],
+      difficultyRating: 3.4,
+      hintText: "9, 52, 406, 1387.",
+      code: [0, 3, 6, 7, 9]
+    },
+    {
+      releaseDate: "2026-06-23",
+      questions: [
+        "Compute: 64 ÷ 8 = ?",
+        "Conversion: How many ounces are in a pound?",
+        "Exponent + addition: 22^2 + 220 = ?",
+        "Multiplication: 587 × 5 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [1, 6],
+        [7, 0, 4],
+        [2, 9, 3, 5],
+        [1, 0, 4, 7, 5]
+      ],
+      difficultyRating: 3.6,
+      hintText: "8, 16, 704, 2935.",
+      code: [1, 0, 4, 7, 5]
+    },
+    {
+      releaseDate: "2026-06-24",
+      questions: [
+        "Combinatorics: How many ways to choose 1 item from 7? (7C1)",
+        "Solve the system for (x,y): 2x = y, y - x = 2",
+        "Addition: 79 + 79 = ?",
+        "Subtraction: 7000 − 961 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [7],
+        [2, 4],
+        [1, 5, 8],
+        [6, 0, 3, 9],
+        [7, 5, 3, 0, 9]
+      ],
+      difficultyRating: 2.9,
+      hintText: "7, 24, 158, 6039.",
+      code: [7, 5, 3, 0, 9]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Add the next week's puzzles to the daily puzzle queue so the app can serve scheduled content for 2026-06-18 through 2026-06-24.

### Description
- Appended seven puzzle objects to the `puzzleSchedule` array in `index.html` for release dates `2026-06-18` through `2026-06-24` containing `questions`, `correctAnswers`, `difficultyRating`, `hintText`, and `code` fields.
- Preserved the existing schedule ordering by relying on the existing `.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))` behavior.
- Kept all puzzle entries shaped consistently (5 questions, 5 answer entries, 5-digit code) to match the runtime expectations of the game logic.

### Testing
- Ran `node --check /tmp/godle-inline.js` to verify inlined script syntax, which succeeded.
- Executed a custom Node validation that parsed `puzzleSchedule` and confirmed the seven new dates are present, all release dates are unique, and every scheduled puzzle has 5 questions, 5 answer rows, and a 5-digit `code`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a299e651c74832da508811589f4f7aa)