### PR TITLE
Add seven daily puzzles (2026-06-25 → 2026-07-01)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1402,6 +1402,146 @@
       difficultyRating: 2.9,
       hintText: "7, 24, 158, 6039.",
       code: [7, 5, 3, 0, 9]
+    },
+    {
+      releaseDate: "2026-06-25",
+      questions: [
+        "Algebra: Solve 3x = 18",
+        "Exponent: Compute 3^4",
+        "Computation: 37 × 25",
+        "Subtraction: 10,000 − 2966",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [8, 1],
+        [9, 2, 5],
+        [7, 0, 3, 4],
+        [9, 1, 5, 6, 4]
+      ],
+      difficultyRating: 4.2,
+      hintText: "6, 81, 925, 7034.",
+      code: [9, 1, 5, 6, 4]
+    },
+    {
+      releaseDate: "2026-06-26",
+      questions: [
+        "Number theory: How many distinct prime factors does 21 have?",
+        "Percent: 85% of 100",
+        "Computation: 358 × 2",
+        "Subtraction: 10,000 − 696",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [8, 5],
+        [7, 1, 6],
+        [9, 3, 0, 4],
+        [7, 5, 0, 4, 8]
+      ],
+      difficultyRating: 2.8,
+      hintText: "2, 85, 716, 9304.",
+      code: [7, 5, 0, 4, 8]
+    },
+    {
+      releaseDate: "2026-06-27",
+      questions: [
+        "Science: How many DNA bases are there? A, C, G, and T.",
+        "Addition: 31 + 22 + 18",
+        "Computation: 463 × 2",
+        "Subtraction: 4000 − 492",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [7, 1],
+        [9, 2, 6],
+        [3, 5, 0, 8],
+        [1, 2, 6, 8, 9]
+      ],
+      difficultyRating: 3.5,
+      hintText: "4, 71, 926, 3508.",
+      code: [1, 2, 6, 8, 9]
+    },
+    {
+      releaseDate: "2026-06-28",
+      questions: [
+        "Geometry: How many Platonic solids are there?",
+        "Geometry: Area of a rectangle with length 7 and width 4",
+        "Computation: 26 × 16",
+        "Addition: 6900 + 193",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [2, 8],
+        [4, 1, 6],
+        [7, 0, 9, 3],
+        [7, 8, 4, 3, 6]
+      ],
+      difficultyRating: 2.9,
+      hintText: "5, 28, 416, 7093.",
+      code: [7, 8, 4, 3, 6]
+    },
+    {
+      releaseDate: "2026-06-29",
+      questions: [
+        "Science: How many primary colors of light are there? RGB.",
+        "Coordinate geometry: y-intercept of 2x + 3y = 21. Enter as a point (x,y).",
+        "Addition: 54 + 61 + 79",
+        "Computation: 573 × 5",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [0, 7],
+        [1, 9, 4],
+        [2, 8, 6, 5],
+        [2, 1, 4, 5, 7]
+      ],
+      difficultyRating: 2.4,
+      hintText: "3, 07, 194, 2865.",
+      code: [2, 1, 4, 5, 7]
+    },
+    {
+      releaseDate: "2026-06-30",
+      questions: [
+        "Compute: √49",
+        "Geometry: Area of a triangle with base 9 and height 8",
+        "Division: 1000 ÷ 4",
+        "Subtraction: 2000 − 511",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [7],
+        [3, 6],
+        [2, 5, 0],
+        [1, 4, 8, 9],
+        [1, 5, 7, 9, 0]
+      ],
+      difficultyRating: 3.8,
+      hintText: "7, 36, 250, 1489.",
+      code: [1, 5, 7, 9, 0]
+    },
+    {
+      releaseDate: "2026-07-01",
+      questions: [
+        "Computation: 0! + 0",
+        "Division: 129 ÷ 3",
+        "Percent: 85% of 800",
+        "Money: A purchase is $20.75, and you pay with a $100 bill. What is the change (no decimal)?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [4, 3],
+        [6, 8, 0],
+        [7, 9, 2, 5],
+        [6, 3, 0, 9, 5]
+      ],
+      difficultyRating: 3.3,
+      hintText: "1, 43, 680, 7925.",
+      code: [6, 3, 0, 9, 5]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Extend the in-app puzzle queue by adding the next seven scheduled daily puzzles so the game has content through July 1, 2026.
- Ensure each new puzzle entry has consistent formatting and that hint text and final codes match the provided answers.

### Description
- Appended seven puzzle objects to the `puzzleSchedule` array in `index.html` for release dates `2026-06-25` through `2026-07-01`, including `questions`, `correctAnswers`, `difficultyRating`, `hintText`, and `code` fields.
- Fixed the July 1 entry so the division answer and hint align with the provided answers by updating the hint text to `"1, 43, 680, 7925."` and keeping the code as `[6, 3, 0, 9, 5]`.
- Cleaned up minor punctuation/spacing in several new prompt strings for consistency.
- Kept the schedule sorted with the existing `sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))` call.

### Testing
- Ran `node --check /tmp/godle-script.js` to validate the extracted puzzle script syntax and it succeeded.
- Executed a validation script `node /tmp/validate-godle.js` that checks for duplicate dates, that the first four question answers cover digits `0-9` exactly once, that final `code` matches the fifth entry, and that `hintText` matches the answers; it completed successfully and reported the last puzzle as `2026-07-01`.
- Ran `git diff --check` to surface whitespace/merge issues and `git status` to confirm the commit; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34195bb080832d81c6d795ee649bf5)