### PR TITLE
Add July 2–9, 2026 puzzle entries to puzzleSchedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -1542,6 +1542,166 @@
       difficultyRating: 3.3,
       hintText: "1, 43, 680, 7925.",
       code: [6, 3, 0, 9, 5]
+    },
+    {
+      releaseDate: "2026-07-02",
+      questions: [
+        "Trivia: How many wheels are on a bicycle?",
+        "Algebra: Solve x/2 + 5 = 42",
+        "Compute: 31^2 − 55",
+        "Subtraction: 2025 − 172",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [7, 4],
+        [9, 0, 6],
+        [1, 8, 5, 3],
+        [9, 0, 6, 5, 3]
+      ],
+      difficultyRating: 3.7,
+      hintText: "2, 74, 906, 1853.",
+      code: [9, 0, 6, 5, 3]
+    },
+    {
+      releaseDate: "2026-07-03",
+      questions: [
+        "Infinite Series: 1 + 1/2 + 1/4 + 1/8 + ...",
+        "Convert: 17/20 into a percent",
+        "Subtraction: 800 − 84 = ?",
+        "Multiplication: 4652 × 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [8, 5],
+        [7, 1, 6],
+        [9, 3, 0, 4],
+        [8, 0, 6, 4, 1]
+      ],
+      difficultyRating: 2.6,
+      hintText: "2, 85, 716, 9304.",
+      code: [8, 0, 6, 4, 1]
+    },
+    {
+      releaseDate: "2026-07-04",
+      questions: [
+        "The press (and media) are considered this numbered estate (branch) in the US",
+        "SCOTUS’s ratio of liberals to conservatives, not reduced (_: _)",
+        "The United States of America is turning this old today",
+        "The year of America’s independence + the number of original colonies = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [3, 6],
+        [2, 5, 0],
+        [1, 7, 8, 9],
+        [4, 7, 8, 6, 9]
+      ],
+      difficultyRating: 2.5,
+      hintText: "4, 36, 250, 1789.",
+      code: [4, 7, 8, 6, 9]
+    },
+    {
+      releaseDate: "2026-07-05",
+      questions: [
+        "Trivia: How many sides does a standard die have?",
+        "Algebra: Solve 7x = 637",
+        "Exponent + addition: 5^3 + 80 = ?",
+        "Subtraction: 8000 − 517 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [9, 1],
+        [2, 0, 5],
+        [7, 4, 8, 3],
+        [5, 1, 8, 3, 9]
+      ],
+      difficultyRating: 3.8,
+      hintText: "6, 91, 205, 7483.",
+      code: [5, 1, 8, 3, 9]
+    },
+    {
+      releaseDate: "2026-07-06",
+      questions: [
+        "How many sides does an obtuse triangle have?",
+        "Line: The y-intercept of 4x + 3y = 27, as a point (x,y)",
+        "Exponent + addition: 2^7 + 46 = ?",
+        "Multiplication: 573 × 5 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [0, 9],
+        [1, 7, 4],
+        [2, 8, 6, 5],
+        [2, 7, 4, 5, 3]
+      ],
+      difficultyRating: 3.8,
+      hintText: "3, 09, 174, 2865.",
+      code: [2, 7, 4, 5, 3]
+    },
+    {
+      releaseDate: "2026-07-07",
+      questions: [
+        "Trivia: Cats are said to have how many lives?",
+        "This percent (%) chance of pulling a club in a standard deck (no jokers)",
+        "Multiplication: 58 × 7 = ?",
+        "Division: 9709 ÷ 7 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [9],
+        [2, 5],
+        [4, 0, 6],
+        [1, 3, 8, 7],
+        [9, 5, 6, 2, 7]
+      ],
+      difficultyRating: 4.3,
+      hintText: "9, 25, 406, 1387.",
+      code: [9, 5, 6, 2, 7]
+    },
+    {
+      releaseDate: "2026-07-08",
+      questions: [
+        "Geometry: The volume of a cube with a side of 2 units",
+        "Conversion: How many ounces are in a pound?",
+        "Exponent + addition: 22^2 + 220 = ?",
+        "Multiplication: 587 × 5 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [1, 6],
+        [7, 0, 4],
+        [2, 9, 3, 5],
+        [1, 9, 4, 0, 5]
+      ],
+      difficultyRating: 3.6,
+      hintText: "8, 16, 704, 2935.",
+      code: [1, 9, 4, 0, 5]
+    },
+    {
+      releaseDate: "2026-07-09",
+      questions: [
+        "Trivia: There are said to be this many deadly sins (traditional count)",
+        "Trivia: The answer to life, the universe and everything, Douglas Adams wrote",
+        "Addition: 79 + 79 = ?",
+        "Subtraction: 7000 − 961 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [7],
+        [4, 2],
+        [1, 5, 8],
+        [6, 0, 3, 9],
+        [7, 4, 8, 9, 0]
+      ],
+      difficultyRating: 2.4,
+      hintText: "7, 42, 158, 6039.",
+      code: [7, 4, 8, 9, 0]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Add the next set of scheduled daily puzzles (2026-07-02 through 2026-07-09) so the site has content queued for early July. 
- Ensure each new puzzle includes questions, `correctAnswers`, `hintText`, `difficultyRating`, and `code` and follows the app rule that the first four answer groups use digits `0-9` exactly once.

### Description
- Appended eight new puzzle objects (one per day from `2026-07-02` to `2026-07-09`) into the `puzzleSchedule` array in `index.html`, each containing `releaseDate`, `questions`, `correctAnswers`, `difficultyRating`, `hintText`, and `code` fields.
- Normalized/adjusted several prompts and hints to match the expected numeric answers (for example the percent conversion entry uses `17/20` so the percent `85` fits digit constraints, a division label was added for clarity, and wording for the trivia items was clarified).
- Kept the schedule sorted by `releaseDate` with the existing `.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))` behavior intact.
- Performed validation that each new puzzle’s first four answer groups collectively contain digits `0-9` exactly once and that each puzzle’s `hintText` and `code` match the declared answers.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues, which completed without errors. 
- Ran a Node-based extraction/validation script that parses the embedded `puzzleSchedule` from `index.html` and verifies parsing, puzzle count, final release date, digit-coverage (0–9 exactly once), hint text consistency, and `code` matching; this script succeeded and reported no issues. 
- Attempted `node --check index.html` for a direct syntax check, which failed because Node does not accept `.html` as a module file type in this environment (this was expected and the embedded schedule was validated via the extraction script instead).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d721e18c4832d9612c99bb5076e21)