### PR TITLE
Update puzzleSchedule: remove June entries and add puzzles for July 10–17

### DIFF
--- a/index.html
+++ b/index.html
@@ -924,606 +924,6 @@
 
    const puzzleSchedule = [
     {
-      releaseDate: "2026-06-01",
-      questions: [
-        "Baseball: How many innings are in a regulation game?",
-        "Solve: 5x = 150",
-        "Compute: 98 + 163 + 303 + 187 = ?",
-        "Compute: 2341 × 2 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [9],
-        [3, 0],
-        [7, 5, 1],
-        [4, 6, 8, 2],
-        [9, 0, 8, 3, 2]
-      ],
-      difficultyRating: 3.9,
-      hintText: "9, 30, 751, 4682.",
-      code: [9, 0, 8, 3, 2]
-    },
-    {
-      releaseDate: "2026-06-02",
-      questions: [
-        "Sides on a pentagon?",
-        "Combinatorics: How many ways to choose 2 items from 8? (8C2)",
-        "Compute: 4998 ÷ 7 = ?",
-        "Compute: 52 × 180 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [5],
-        [2, 8],
-        [7, 1, 4],
-        [9, 3, 6, 0],
-        [9, 8, 6, 0, 5]
-      ],
-      difficultyRating: 3.0,
-      hintText: "5, 28, 714, 9360.",
-      code: [9, 8, 6, 0, 5]
-    },
-    {
-      releaseDate: "2026-06-03",
-      questions: [
-        "Algebra: How many real solutions does x^2 - 4 = 0 have?",
-        "Compute: 100 - 16 = ?",
-        "Solve the system (x,y,z): x = 7, x - 1 = z, x - y = z",
-        "Compute: 4526 × 2 + 1 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [2],
-        [8, 4],
-        [7, 1, 6],
-        [9, 0, 5, 3],
-        [5, 4, 6, 3, 7]
-      ],
-      difficultyRating: 4.5,
-      hintText: "2, 84, 716, 9053.",
-      code: [5, 4, 6, 3, 7]
-    },
-    {
-      releaseDate: "2026-06-04",
-      questions: [
-        "Trivia: How many strings does a standard guitar have?",
-        "Geometry: Area of a 9 by 9 square = ?",
-        "Compute: 37 × 25 = ?",
-        "Compute: 14068 ÷ 2 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [6],
-        [8, 1],
-        [9, 2, 5],
-        [7, 0, 3, 4],
-        [7, 1, 5, 3, 4]
-      ],
-      difficultyRating: 3.9,
-      hintText: "6, 81, 925, 7034.",
-      code: [7, 1, 5, 3, 4]
-    },
-    {
-      releaseDate: "2026-06-05",
-      questions: [
-        "Trivia: How many suits are in a standard deck of cards?",
-        "Compute: 7^2 + 22 = ?",
-        "Compute: 4630 ÷ 5 = ?",
-        "Compute: 1754 × 2 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [4],
-        [7, 1],
-        [9, 2, 6],
-        [3, 5, 0, 8],
-        [9, 1, 6, 5, 8]
-      ],
-      difficultyRating: 3.1,
-      hintText: "4, 71, 926, 3508.",
-      code: [9, 1, 6, 5, 8]
-    },
-    {
-      releaseDate: "2026-06-06",
-      questions: [
-        "Algebra: How many real roots does x(x−1)(x+1)=0 have?",
-        "Coordinate geometry: y-intercept of y = −3x + 4 as (x,y)",
-        "Compute: 97 + 97 + 3 = ?",
-        "Compute: 573 × 5 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [3],
-        [0, 4],
-        [1, 9, 7],
-        [2, 8, 6, 5],
-        [2, 7, 6, 5, 8]
-      ],
-      difficultyRating: 4.4,
-      hintText: "3, 04, 197, 2865.",
-      code: [2, 7, 6, 5, 8]
-    },
-    {
-      releaseDate: "2026-06-07",
-      questions: [
-        "Trivia: How many Platonic solids are there?",
-        "Percent: 70% of 40 = ?",
-        "Compute: 26 × 16 = ?",
-        "Compute: 6800 + 293 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [5],
-        [2, 8],
-        [4, 1, 6],
-        [7, 0, 9, 3],
-        [5, 8, 9, 7, 3]
-      ],
-      difficultyRating: 2.7,
-      hintText: "5, 28, 416, 7093.",
-      code: [5, 8, 9, 7, 3]
-    },
-    {
-      releaseDate: "2026-06-08",
-      questions: [
-        "Compute: 0.25 × 8 = ?",
-        "Compute: 17 × 5 = ?",
-        "Compute: 358 × 2 = ?",
-        "Compute: 4652 × 2 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [2],
-        [8, 5],
-        [7, 1, 6],
-        [9, 3, 0, 4],
-        [9, 5, 6, 4, 1]
-      ],
-      difficultyRating: 3.3,
-      hintText: "2, 85, 716, 9304.",
-      code: [9, 5, 6, 4, 1]
-    },
-    {
-      releaseDate: "2026-06-09",
-      questions: [
-        "Trivia: How many innings are in a regulation baseball game?",
-        "Evaluate: 23x, x = 2",
-        "Solve for y: 2y = 540",
-        "Compute: 277 × 5 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [9],
-        [4, 6],
-        [2, 7, 0],
-        [1, 3, 8, 5],
-        [9, 7, 0, 4, 5]
-      ],
-      difficultyRating: 4.2,
-      hintText: "9, 46, 270, 1385.",
-      code: [9, 7, 0, 4, 5]
-    },
-    {
-      releaseDate: "2026-06-10",
-      questions: [
-        "Combinatorics: How many ways to choose 0 items from 7? (7C0)",
-        "Compute: 7^2 + 4 = ?",
-        "Percent: 85% of 800 = ?",
-        "Compute: 8000 − 76 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [1],
-        [5, 3],
-        [6, 8, 0],
-        [7, 9, 2, 4],
-        [7, 9, 0, 3, 4]
-      ],
-      difficultyRating: 2.9,
-      hintText: "1, 53, 680, 7924.",
-      code: [7, 9, 0, 3, 4]
-    },
-    {
-      releaseDate: "2026-06-11",
-      questions: [
-        "Algebra: Solve 3x = 18",
-        "Exponent: Compute 3^4",
-        "Solve for a,b,c: a = 2b + c, c - b = 3,c = 5",
-        "Computation: 3517 × 2",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [6],
-        [8, 1],
-        [9, 2, 5],
-        [7, 0, 3, 4],
-        [8, 1, 5, 3, 4]
-      ],
-      difficultyRating: 4.7,
-      hintText: "6, 81, 925, 7034.",
-      code: [8, 1, 5, 3, 4]
-    },
-    {
-      releaseDate: "2026-06-12",
-      questions: [
-        "Geometry: How many faces does a tetrahedron have?",
-        "Compute: 100 − 29",
-        "Compute: 2778 ÷ 3",
-        "Compute: 1754 × 2",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [4],
-        [7, 1],
-        [9, 2, 6],
-        [3, 5, 0, 8],
-        [5, 2, 6, 8, 4]
-      ],
-      difficultyRating: 2.8,
-      hintText: "4, 71, 926, 3508.",
-      code: [5, 2, 6, 8, 4]
-    },
-    {
-      releaseDate: "2026-06-13",
-      questions: [
-        "Probability: In 4 coin flips, the expected number of heads is? ",
-        "Algebra: Solve 5x = 425",
-        "Compute: 358 × 2",
-        "Compute: 6130 + 3214 - 40",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [2],
-        [8, 5],
-        [7, 1, 6],
-        [9, 3, 0, 4],
-        [8, 5, 0, 4, 3]
-      ],
-      difficultyRating: 3.1,
-      hintText: "2, 85, 716, 9304.",
-      code: [8, 5, 0, 4, 3]
-    },
-    {
-      releaseDate: "2026-06-14",
-      questions: [
-        "Solve: 3x = 9",
-        "Compute: 7 × 10",
-        "Compute: 54 + 52 + 44 + 44",
-        "Compute: 9999 - 3741 ",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [3],
-        [7, 0],
-        [1, 9, 4],
-        [6, 2, 5, 8],
-        [6, 2, 4, 5, 8]
-      ],
-      difficultyRating: 2.6,
-      hintText: "3, 70, 194, 6258.",
-      code: [6, 2, 4, 5, 8]
-    },
-    {
-      releaseDate: "2026-06-15",
-      questions: [
-        "Logic: 23 + 56 = 79, 1 = true or 0 = false",
-        "Compute: 7 ÷ 20 × 100",
-        "Discount: If an item is 15% off $800, how much is it?",
-        "Money: Change from $100 if the purchase cost $20.76 (no decimal)",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [1],
-        [3, 5],
-        [6, 8, 0],
-        [7, 9, 2, 4],
-        [2, 9, 0, 4, 1]
-      ],
-      difficultyRating: 4.4,
-      hintText: "1, 35, 680, 7924.",
-      code: [2, 9, 0, 4, 1]
-    },
-    {
-      releaseDate: "2026-06-16",
-      questions: [
-        "Compute: 936 ÷ 104",
-        "Compute: 21 + 31",
-        "Compute: 203 × 2",
-        "Compute: 1500 − 113",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [9],
-        [5, 2],
-        [4, 0, 6],
-        [1, 3, 8, 7],
-        [5, 0, 8, 1, 7]
-      ],
-      difficultyRating: 3.9,
-      hintText: "9, 52, 406, 1387.",
-      code: [5, 0, 8, 1, 7]
-    },
-    {
-      releaseDate: "2026-06-17",
-      questions: [
-        "Geometry: How many sides does a regular pentagon have?",
-        "Geometry: Perimeter of a 9 by 5 rectangle",
-        "Geometry: Area of a rectangle with a length = 17 and width = 42",
-        "Geometry: 26 times around a circle in degrees (1 rotation = 360°)",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [5],
-        [2, 8],
-        [7, 1, 4],
-        [9, 3, 6, 0],
-        [5, 8, 4, 7, 0]
-      ],
-      difficultyRating: 3.6,
-      hintText: "5, 28, 714, 9360.",
-      code: [5, 8, 4, 7, 0]
-    },
-    {
-      releaseDate: "2026-06-18",
-      questions: [
-        "Geometry: How many sides does a tetrahedron have?",
-        "Division: 497 ÷ 7 = ?",
-        "Subtraction: 1000 − 74 = ?",
-        "Subtraction: 1703 + 1805 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [4],
-        [7, 1],
-        [9, 2, 6],
-        [3, 5, 0, 8],
-        [3, 1, 6, 0, 8]
-      ],
-      difficultyRating: 3.0,
-      hintText: "4, 71, 926, 3508.",
-      code: [3, 1, 6, 0, 8]
-    },
-    {
-      releaseDate: "2026-06-19",
-      questions: [
-        "Probabailty: How many outcomes when flipping a fair coin?",
-        "Percent: 17 out of 20 as a percentage = ?(%)",
-        "Subtraction: 800 − 84 = ?",
-        "Multiplication: 4652 × 2 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [2],
-        [8, 5],
-        [7, 1, 6],
-        [9, 3, 0, 4],
-        [8, 1, 5, 4, 6]
-      ],
-      difficultyRating: 2.6,
-      hintText: "2, 85, 716, 9304.",
-      code: [8, 1, 5, 4, 6]
-    },
-    {
-      releaseDate: "2026-06-20",
-      questions: [
-        "Word problem: The product of two and three?",
-        "Algebra: Solve 7x = 637",
-        "Compute: 5^3 + 80 = ?",
-        "Subtraction: 8000 − 517 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [6],
-        [9, 1],
-        [2, 0, 5],
-        [7, 4, 8, 3],
-        [5, 4, 8, 3, 6]
-      ],
-      difficultyRating: 3.8,
-      hintText: "6, 91, 205, 7483.",
-      code: [5, 4, 8, 3, 6]
-    },
-    {
-      releaseDate: "2026-06-21",
-      questions: [
-        "Science: How many primary colors of light are there (RGB)?",
-        "Line: y-intercept of y = 2x + 4 as a point (x,y). ",
-        "Compute: 2^7 + 69 = ?",
-        "Multiplication: 573 × 5 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [3],
-        [0, 4],
-        [1, 9, 7],
-        [2, 8, 6, 5],
-        [1, 4, 7, 5, 2]
-      ],
-      difficultyRating: 3.2,
-      hintText: "3, 04, 197, 2865.",
-      code: [1, 4, 7, 5, 2]
-    },
-    {
-      releaseDate: "2026-06-22",
-      questions: [
-        "Trivia: Cats are said to have how many lives?",
-        "Trivia: How many cards are in a standard deck? (w/o Jokers)",
-        "Multiplication: 29 × 14 = ?",
-        "Subtraction: 2000 − 613 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [9],
-        [5, 2],
-        [4, 0, 6],
-        [1, 3, 8, 7],
-        [0, 3, 6, 7, 9]
-      ],
-      difficultyRating: 3.4,
-      hintText: "9, 52, 406, 1387.",
-      code: [0, 3, 6, 7, 9]
-    },
-    {
-      releaseDate: "2026-06-23",
-      questions: [
-        "Compute: 64 ÷ 8 = ?",
-        "Conversion: How many ounces are in a pound?",
-        "Exponent + addition: 22^2 + 220 = ?",
-        "Multiplication: 587 × 5 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [8],
-        [1, 6],
-        [7, 0, 4],
-        [2, 9, 3, 5],
-        [1, 0, 4, 7, 5]
-      ],
-      difficultyRating: 3.6,
-      hintText: "8, 16, 704, 2935.",
-      code: [1, 0, 4, 7, 5]
-    },
-    {
-      releaseDate: "2026-06-24",
-      questions: [
-        "Combinatorics: How many ways to choose 1 item from 7? (7C1)",
-        "Solve the system for (x,y): 2x = y, y - x = 2",
-        "Addition: 79 + 79 = ?",
-        "Subtraction: 7000 − 961 = ?",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [7],
-        [2, 4],
-        [1, 5, 8],
-        [6, 0, 3, 9],
-        [7, 5, 3, 0, 9]
-      ],
-      difficultyRating: 2.9,
-      hintText: "7, 24, 158, 6039.",
-      code: [7, 5, 3, 0, 9]
-    },
-    {
-      releaseDate: "2026-06-25",
-      questions: [
-        "Algebra: Solve 3x = 18",
-        "Exponent: Compute 3^4",
-        "Computation: 37 × 25",
-        "Subtraction: 10,000 − 2966",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [6],
-        [8, 1],
-        [9, 2, 5],
-        [7, 0, 3, 4],
-        [9, 1, 5, 6, 4]
-      ],
-      difficultyRating: 4.2,
-      hintText: "6, 81, 925, 7034.",
-      code: [9, 1, 5, 6, 4]
-    },
-    {
-      releaseDate: "2026-06-26",
-      questions: [
-        "Number theory: How many distinct prime factors does 21 have?",
-        "Percent: 85% of 100",
-        "Computation: 358 × 2",
-        "Subtraction: 10,000 − 696",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [2],
-        [8, 5],
-        [7, 1, 6],
-        [9, 3, 0, 4],
-        [7, 5, 0, 4, 8]
-      ],
-      difficultyRating: 2.8,
-      hintText: "2, 85, 716, 9304.",
-      code: [7, 5, 0, 4, 8]
-    },
-    {
-      releaseDate: "2026-06-27",
-      questions: [
-        "Science: How many DNA bases are there? A, C, G, and T.",
-        "Addition: 31 + 22 + 18",
-        "Computation: 463 × 2",
-        "Subtraction: 4000 − 492",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [4],
-        [7, 1],
-        [9, 2, 6],
-        [3, 5, 0, 8],
-        [1, 2, 6, 8, 9]
-      ],
-      difficultyRating: 3.5,
-      hintText: "4, 71, 926, 3508.",
-      code: [1, 2, 6, 8, 9]
-    },
-    {
-      releaseDate: "2026-06-28",
-      questions: [
-        "Geometry: How many Platonic solids are there?",
-        "Geometry: Area of a rectangle with length 7 and width 4",
-        "Computation: 26 × 16",
-        "Addition: 6900 + 193",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [5],
-        [2, 8],
-        [4, 1, 6],
-        [7, 0, 9, 3],
-        [7, 8, 4, 3, 6]
-      ],
-      difficultyRating: 2.9,
-      hintText: "5, 28, 416, 7093.",
-      code: [7, 8, 4, 3, 6]
-    },
-    {
-      releaseDate: "2026-06-29",
-      questions: [
-        "Science: How many primary colors of light are there? RGB.",
-        "Coordinate geometry: y-intercept of 2x + 3y = 21. Enter as a point (x,y).",
-        "Addition: 54 + 61 + 79",
-        "Computation: 573 × 5",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [3],
-        [0, 7],
-        [1, 9, 4],
-        [2, 8, 6, 5],
-        [2, 1, 4, 5, 7]
-      ],
-      difficultyRating: 2.4,
-      hintText: "3, 07, 194, 2865.",
-      code: [2, 1, 4, 5, 7]
-    },
-    {
-      releaseDate: "2026-06-30",
-      questions: [
-        "Compute: √49",
-        "Geometry: Area of a triangle with base 9 and height 8",
-        "Division: 1000 ÷ 4",
-        "Subtraction: 2000 − 511",
-        "Enter the final 5-digit code"
-      ],
-      correctAnswers: [
-        [7],
-        [3, 6],
-        [2, 5, 0],
-        [1, 4, 8, 9],
-        [1, 5, 7, 9, 0]
-      ],
-      difficultyRating: 3.8,
-      hintText: "7, 36, 250, 1489.",
-      code: [1, 5, 7, 9, 0]
-    },
-    {
       releaseDate: "2026-07-01",
       questions: [
         "Computation: 0! + 0",
@@ -1702,6 +1102,166 @@
       difficultyRating: 2.4,
       hintText: "7, 42, 158, 6039.",
       code: [7, 4, 8, 9, 0]
+    },
+    {
+      releaseDate: "2026-07-10",
+      questions: [
+        "Vocabulary: How many terms are in a trinomial?",
+        "Algebra: Solve x/2 + 5 = 52",
+        "Exponent/Subtraction: 28^2 − 78",
+        "Place Value: Write 1 thousand + 8 hundreds + 5 tens + 2 ones as a number",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [9, 4],
+        [7, 0, 6],
+        [1, 8, 5, 2],
+        [1, 6, 5, 2, 0]
+      ],
+      difficultyRating: 3.7,
+      hintText: "3, 94, 706, 1852.",
+      code: [1, 6, 5, 2, 0]
+    },
+    {
+      releaseDate: "2026-07-11",
+      questions: [
+        "Sports: In rugby sevens, how many players are on one side?",
+        "Geometry: A triangle has angles 60° and 90°. What is the third angle?",
+        "Subtraction: 1000 − 149",
+        "Algebra: Evaluate 5n − 74 when n = 1000",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [7],
+        [3, 0],
+        [8, 5, 1],
+        [4, 9, 2, 6],
+        [8, 9, 1, 6, 0]
+      ],
+      difficultyRating: 4.6,
+      hintText: "7, 30, 851, 4926.",
+      code: [8, 9, 1, 6, 0]
+    },
+    {
+      releaseDate: "2026-07-12",
+      questions: [
+        "Trivia: How many Olympic rings are there?",
+        "Algebra: Find the y-intercept (x,y) of the line -5x + 2y = 16",
+        "Subtraction: 400 − 83",
+        "Algebra: Evaluate 6n^3 + 3n^2 − 6 when n = 10",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [0, 8],
+        [3, 1, 7],
+        [6, 2, 9, 4],
+        [0, 8, 6, 4, 9]
+      ],
+      difficultyRating: 3.2,
+      hintText: "5, 08, 317, 6294.",
+      code: [0, 8, 6, 4, 9]
+    },
+    {
+      releaseDate: "2026-07-13",
+      questions: [
+        "Science: How many natural moons does Earth have?",
+        "Number Theory: Least common multiple of 7 and 9",
+        "Time: How many minutes are in 14 hours?",
+        "Subtraction: 3000 − 25",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [6, 3],
+        [8, 4, 0],
+        [2, 9, 7, 5],
+        [8, 3, 0, 2, 5]
+      ],
+      difficultyRating: 3.2,
+      hintText: "1, 63, 840, 2975.",
+      code: [8, 3, 0, 2, 5]
+    },
+    {
+      releaseDate: "2026-07-14",
+      questions: [
+        "Geometry: How many corners are on a cube?",
+        "Compute: 3^3",
+        "Compute: 8^3 + 1^3",
+        "Compute: 16^3",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [2, 7],
+        [5, 1, 3],
+        [4, 0, 9, 6],
+        [8, 4, 3, 6, 1]
+      ],
+      difficultyRating: 2.7,
+      hintText: "8, 27, 513, 4096.",
+      code: [8, 4, 3, 6, 1]
+    },
+    {
+      releaseDate: "2026-07-15",
+      questions: [
+        "Biology: How many legs does a spider have?",
+        "Area: A rectangle with a length of 3 and width of 5",
+        "Subtraction: 606 − 3",
+        "Exponent/Addition: 50^2 + 249",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [1, 5],
+        [6, 0, 3],
+        [2, 7, 4, 9],
+        [1, 7, 3, 9, 6]
+      ],
+      difficultyRating: 2.8,
+      hintText: "8, 15, 603, 2749.",
+      code: [1, 7, 3, 9, 6]
+    },
+    {
+      releaseDate: "2026-07-16",
+      questions: [
+        "Area: A trapezoid with height 3 and bases 1 and 5",
+        "Chemistry: What is iron’s atomic number?",
+        "Division: 1060 ÷ 2",
+        "Subtraction: 9000 − 826",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [9],
+        [2, 6],
+        [5, 3, 0],
+        [8, 1, 7, 4],
+        [2, 6, 5, 4, 7]
+      ],
+      difficultyRating: 2.9,
+      hintText: "9, 26, 530, 8174.",
+      code: [2, 6, 5, 4, 7]
+    },
+    {
+      releaseDate: "2026-07-17",
+      questions: [
+        "Algebra: How many real solutions does x^2 + 18 = 0 have?",
+        "Roman Numerals: XCII = ?",
+        "Percent: 25% of 1900",
+        "Multiplication: 819 × 2",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [0],
+        [9, 2],
+        [4, 7, 5],
+        [1, 6, 3, 8],
+        [9, 6, 5, 2, 8]
+      ],
+      difficultyRating: 4.1,
+      hintText: "0, 92, 475, 1638.",
+      code: [9, 6, 5, 2, 8]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation

- Replace an outdated set of daily puzzle entries with a trimmed schedule and add new puzzles for mid-July to keep the site current.

### Description

- Removed a large block of historical June `puzzleSchedule` entries and kept the active July entries in `index.html`.
- Added new puzzle objects for `2026-07-10` through `2026-07-17` including `questions`, `correctAnswers`, `hintText`, `difficultyRating`, and `code` fields.
- Left the schedule sorting call `[].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))` intact so entries remain chronological.
- No logic changes were made outside updating the static `puzzleSchedule` data in `index.html`.

### Testing

- No automated tests were run because this change only modifies static puzzle data in `index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46a1c684e4832dabe17f827780e195)