### PR TITLE
Update footer copyright to © 2026 Godle Games LLC

### DIFF
--- a/index.html
+++ b/index.html
@@ -901,7 +901,7 @@
     <div id="copy-message" aria-live="polite">Copied to clipboard!</div>
   </div>
 
-  <footer>created by Cordell Booth • <a href="https://patreon.com/GodleCreator" target="_blank">Donate</a> • <a href="https://www.facebook.com/groups/2109717096181882" target="_blank">Community</a></footer>
+  <footer>© 2026 Godle Games LLC • <a href="https://patreon.com/GodleCreator" target="_blank">Donate</a> • <a href="https://www.facebook.com/groups/2109717096181882" target="_blank">Community</a></footer>
 
   <script type="module">
     import { createClient } from "https://esm.sh/@supabase/supabase-js@2";


### PR DESCRIPTION
### Motivation
- Update the site footer attribution to a company copyright notice for 2026.

### Description
- Replace the text `created by Cordell Booth` with `© 2026 Godle Games LLC` in `index.html` (footer at line 904).

### Testing
- Verified the change with `rg -n "© 2026 Godle Games LLC|created by Cordell Booth" index.html` which found the new text, and confirmed the file was staged and committed via `git status --short` and `git commit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e9119b18c832d95c2c628f59fcec0)