### PR TITLE
Add July 17–23 puzzles to schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -1246,22 +1246,142 @@
     {
       releaseDate: "2026-07-17",
       questions: [
-        "Algebra: How many real solutions does x^2 + 18 = 0 have?",
-        "Roman Numerals: XCII = ?",
-        "Percent: 25% of 1900",
-        "Multiplication: 819 × 2",
+        "Biology: How many chambers are in the human heart?",
+        "Chemistry: What is the atomic number of bismuth?",
+        "Subtraction: Compute 900 − 139",
+        "Exponent and subtraction: Compute 46² − 57",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [8, 3],
+        [7, 6, 1],
+        [2, 0, 5, 9],
+        [8, 6, 5, 7, 9]
+      ],
+      difficultyRating: 4.9,
+      hintText: "4, 83, 761, 2059.",
+      code: [8, 6, 5, 7, 9]
+    },
+    {
+      releaseDate: "2026-07-18",
+      questions: [
+        "Geometry: How many vertices does a heptagon have?",
+        "Biology: How many chromosomes are normally in a human somatic cell?",
+        "Division: Compute 812 ÷ 4",
+        "A venue has 10,000 seats, and 815 are empty. How many seats are occupied?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [7],
+        [4, 6],
+        [2, 0, 3],
+        [9, 1, 8, 5],
+        [0, 6, 8, 5, 7]
+      ],
+      difficultyRating: 4.1,
+      hintText: "7, 46, 203, 9185.",
+      code: [0, 6, 8, 5, 7]
+    },
+    {
+      releaseDate: "2026-07-19",
+      questions: [
+        "Geography: How many Great Lakes are there?",
+        "Subtraction: Compute 100 − 27",
+        "Multiplication: Compute 102 × 4",
+        "Exponent and addition: Compute 9³ + 900",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [7, 3],
+        [4, 0, 8],
+        [1, 6, 2, 9],
+        [4, 6, 8, 9, 5]
+      ],
+      difficultyRating: 3.8,
+      hintText: "5, 73, 408, 1629.",
+      code: [4, 6, 8, 9, 5]
+    },
+    {
+      releaseDate: "2026-07-20",
+      questions: [
+        "Computer science: How many bits are in one byte?",
+        "Solve the system: 2x + 1 = y; x + y = 10",
+        "Geometry: Find the volume of a rectangular prism measuring 9 × 10 × 6",
+        "Algebra: Solve x + 739 = 3700",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [3, 7],
+        [5, 4, 0],
+        [2, 9, 6, 1],
+        [3, 4, 6, 0, 1]
+      ],
+      difficultyRating: 4.2,
+      hintText: "8, 37, 540, 2961.",
+      code: [3, 4, 6, 0, 1]
+    },
+    {
+      releaseDate: "2026-07-21",
+      questions: [
+        "Mythology: How many Muses are there in Greek mythology?",
+        "Area: A triangle with a base of 4 and a height of 7",
+        "Exponent and subtraction: Compute 11³ − 605",
+        "Place value: Write 3 thousands, 5 tens, and 8 ones as a number",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [9],
+        [1, 4],
+        [7, 2, 6],
+        [3, 0, 5, 8],
+        [7, 2, 5, 8, 3]
+      ],
+      difficultyRating: 3.9,
+      hintText: "9, 14, 726, 3058.",
+      code: [7, 2, 5, 8, 3]
+    },
+    {
+      releaseDate: "2026-07-22",
+      questions: [
+        "Sports: How many points is a touchdown worth (before the extra-point attempt)?",
+        "Division: 273 ÷ 3 = ?",
+        "Exponent and addition: Compute 6³ + 216",
+        "Multiplication: 3529 × 2 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [9, 1],
+        [4, 3, 2],
+        [7, 0, 5, 8],
+        [4, 9, 5, 8, 1]
+      ],
+      difficultyRating: 3.6,
+      hintText: "6, 91, 432, 7058.",
+      code: [4, 9, 5, 8, 1]
+    },
+    {
+      releaseDate: "2026-07-23",
+      questions: [
+        "Number theory: The first whole number?",
+        "Spatial reasoning: How many unit cubes form a 3 × 3 × 3 cube?",
+        "Roman numerals: Convert CDXVI to a decimal number",
+        "A warehouse begins with 9,000 units and ships 461. How many units remain?",
         "Enter the final 5-digit code"
       ],
       correctAnswers: [
         [0],
-        [9, 2],
-        [4, 7, 5],
-        [1, 6, 3, 8],
-        [9, 6, 5, 2, 8]
+        [2, 7],
+        [4, 1, 6],
+        [8, 5, 3, 9],
+        [4, 2, 6, 9, 1]
       ],
-      difficultyRating: 4.1,
-      hintText: "0, 92, 475, 1638.",
-      code: [9, 6, 5, 2, 8]
+      difficultyRating: 3.7,
+      hintText: "0, 27, 416, 8539.",
+      code: [4, 2, 6, 9, 1]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Populate the in-app daily puzzle schedule for 2026-07-17 through 2026-07-23 so players receive the new puzzles on those dates.
- Ensure each puzzle entry includes full metadata required by the game: questions, `correctAnswers`, `hintText`, `difficultyRating`, and `code`.

### Description
- Replaced the existing July 17 entry and added new puzzle objects for `2026-07-17` through `2026-07-23` inside the `puzzleSchedule` array in `index.html` with the supplied questions and answers.
- Each added puzzle includes the `questions`, `correctAnswers`, `difficultyRating`, `hintText`, and final `code` arrays formatted to match existing schedule entries.
- The `puzzleSchedule` array remains sorted with `.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));` so releases are unchanged.
- No other application logic was modified beyond injecting the new schedule entries.

### Testing
- Ran `node --check /tmp/godle-script.js` to validate the extracted script syntax and it passed.
- Executed Python arithmetic assertions to verify puzzle answer math with `python3` and they all passed (checks for sums, products, divisions, subtractions, exponents).
- Verified presence of scheduled dates with a Python presence check for `2026-07-17` through `2026-07-23` and it passed.
- Ran `git diff --check` for whitespace/errors and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5002c1ad38832da1dbc522430e553a)