### PR TITLE
Add daily puzzle entries for 2026-07-24 through 2026-08-01

### DIFF
--- a/index.html
+++ b/index.html
@@ -1382,6 +1382,186 @@
       difficultyRating: 3.7,
       hintText: "0, 27, 416, 8539.",
       code: [4, 2, 6, 9, 1]
+    },
+    {
+      releaseDate: "2026-07-24",
+      questions: [
+        "Chess: At the start of a chess game, how many pawns does one player have?",
+        "Money: How many cents are in a quarter?",
+        "Roman numerals: Convert CDXVII to a decimal number",
+        "Multiplication: Compute 3201 × 3",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [2, 5],
+        [4, 1, 7],
+        [9, 6, 0, 3],
+        [2, 1, 7, 6, 3]
+      ],
+      difficultyRating: 3.6,
+      hintText: "8, 25, 417, 9603.",
+      code: [2, 1, 7, 6, 3]
+    },
+    {
+      releaseDate: "2026-07-25",
+      questions: [
+        "Geometry: How many vertices does a triangle have?",
+        "Divide: 602 ÷ 7 = ?",
+        "Geometry: A straight angle plus a right angle equals how many degrees?",
+        "Subtraction: Compute 6000 − 806",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [3],
+        [8, 6],
+        [2, 7, 0],
+        [5, 1, 9, 4],
+        [8, 7, 9, 1, 4]
+      ],
+      difficultyRating: 3.8,
+      hintText: "3, 86, 270, 5194.",
+      code: [8, 7, 9, 1, 4]
+    },
+    {
+      releaseDate: "2026-07-26",
+      questions: [
+        "Chemistry: How many carbon atoms are in benzene, C6H6?",
+        "Subtraction: Compute 100 − 8",
+        "Time: How many minutes are in 8 hours and 28 minutes?",
+        "Algebra: Solve x + 257 = 2000",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [9, 2],
+        [5, 0, 8],
+        [1, 7, 4, 3],
+        [6, 7, 4, 3, 9]
+      ],
+      difficultyRating: 3.5,
+      hintText: "6, 92, 508, 1743.",
+      code: [6, 7, 4, 3, 9]
+    },
+    {
+      releaseDate: "2026-07-27",
+      questions: [
+        "Algebra: The real solutions, how many solutions does x^2 + 18 = 0 have?",
+        "Roman Numerals: XCII = ?",
+        "Percent: 25% of 1900",
+        "Multiplication: 819 × 2",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [0],
+        [9, 2],
+        [4, 7, 5],
+        [1, 6, 3, 8],
+        [9, 6, 5, 2, 8]
+      ],
+      difficultyRating: 3.7,
+      hintText: "0, 92, 475, 1638.",
+      code: [9, 6, 5, 2, 8]
+    },
+    {
+      releaseDate: "2026-07-28",
+      questions: [
+        "321 × 0 = ?",
+        "Fill in the missing numbers: 1, 2, 3, _, _, 6, ...",
+        "If 6 is in the tens place, 9 is in the ones place, and 3 is in the hundreds place, what is the number?",
+        "426 × 3 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [0],
+        [4, 5],
+        [3, 6, 9],
+        [1, 2, 7, 8],
+        [4, 6, 7, 8, 5]
+      ],
+      difficultyRating: 1.2,
+      hintText: "0, 45, 369, 1278.",
+      code: [4, 6, 7, 8, 5]
+    },
+    {
+      releaseDate: "2026-07-29",
+      questions: [
+        "Geometry: How many centers does a circle have?",
+        "Exponent: Compute 7²",
+        "Multiplication: Compute 127 × 5",
+        "Place value: Write 8 thousands, 2 hundreds, 0 tens, and 7 ones as a number",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [4, 9],
+        [6, 3, 5],
+        [8, 2, 0, 7],
+        [4, 3, 6, 7, 0]
+      ],
+      difficultyRating: 3.2,
+      hintText: "1, 49, 635, 8207.",
+      code: [4, 3, 6, 7, 0]
+    },
+    {
+      releaseDate: "2026-07-30",
+      questions: [
+        "Algebra: How many real solutions does |x| = -5 have?",
+        "Exponent: Compute 8²",
+        "Subtraction: Compute 1000 − 68",
+        "Multiply: 1939 × 3 = ?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [0],
+        [6, 4],
+        [9, 3, 2],
+        [5, 8, 1, 7],
+        [2, 8, 1, 7, 0]
+      ],
+      difficultyRating: 3.5,
+      hintText: "0, 64, 932, 5817.",
+      code: [2, 8, 1, 7, 0]
+    },
+    {
+      releaseDate: "2026-07-31",
+      questions: [
+        "Find the average (mean): 4, 5, 6, 8, 12",
+        "Time: How many minutes are in a quarter hour?",
+        "Subtraction: Compute 1000 − 171",
+        "Algebra: Evaluate 4n + 63 when n = 1000",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [7],
+        [1, 5],
+        [8, 2, 9],
+        [4, 0, 6, 3],
+        [5, 2, 9, 3, 8]
+      ],
+      difficultyRating: 3.0,
+      hintText: "7, 15, 829, 4063.",
+      code: [5, 2, 9, 3, 8]
+    },
+    {
+      releaseDate: "2026-08-01",
+      questions: [
+        "Language: How many vowels are in the English alphabet? (excluding ‘Y’)",
+        "Clock math: How many degrees does the minute hand move in 5 minutes?",
+        "Subtraction: Compute 1000 − 36",
+        "Multiplication: Compute 891 × 8",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [3, 0],
+        [9, 6, 4],
+        [7, 1, 2, 8],
+        [6, 1, 4, 8, 7]
+      ],
+      difficultyRating: 4.2,
+      hintText: "5, 30, 964, 7128.",
+      code: [6, 1, 4, 8, 7]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Populate the puzzles dataset with upcoming daily entries so the app can serve scheduled puzzles from late July into early August 2026. 
- Ensure each release has full metadata (`questions`, `correctAnswers`, `difficultyRating`, `hintText`, and `code`) to match the existing puzzle schema. 
- Keep the array chronologically consistent so the existing release scheduling logic continues to work.

### Description
- Inserted nine puzzle objects for release dates `2026-07-24` through `2026-08-01` into the puzzles array in `index.html`.
- Each object follows the existing structure and includes `questions`, `correctAnswers`, `difficultyRating`, `hintText`, and `code` fields.
- No functional logic was changed; the existing `.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))` usage remains in place.

### Testing
- No automated tests were executed for this data-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57e1c2726c832d81c101fe78128610)