### PR TITLE
Replace Donate footer link with Email

### DIFF
--- a/index.html
+++ b/index.html
@@ -901,7 +901,7 @@
     <div id="copy-message" aria-live="polite">Copied to clipboard!</div>
   </div>
 
-  <footer>© 2026 Godle Games LLC • <a href="https://patreon.com/GodleCreator" target="_blank">Donate</a> • <a href="https://www.facebook.com/groups/2109717096181882" target="_blank">Community</a></footer>
+  <footer>© 2026 Godle Games LLC • <a href="mailto:godlegames33@gmail.com">Email</a> • <a href="https://www.facebook.com/groups/2109717096181882" target="_blank">Community</a></footer>
 
   <script type="module">
     import { createClient } from "https://esm.sh/@supabase/supabase-js@2";


### PR DESCRIPTION
### Motivation
- Replace the external Patreon "Donate" footer link with an Email link that opens the device's email composer addressed to `godlegames33@gmail.com`.

### Description
- Update `index.html` footer to replace the `<a>` targeting `https://patreon.com/GodleCreator` labeled "Donate" with a `mailto:godlegames33@gmail.com` link labeled "Email".

### Testing
- Ran `git diff --check` and an inline Python assertion (`python3 - <<'PY' ...`) that verifies the `mailto:godlegames33@gmail.com` link is present and the Patreon URL is removed; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e92039934832db1899195dba455ae)