### PR TITLE
Add Google tag and conversion event tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,15 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- Google Analytics additions begin: Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-18338723826"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'AW-18338723826');
+  </script>
+  <!-- Google Analytics additions end: Google tag (gtag.js) -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Gödle</title>
@@ -841,7 +850,7 @@
   <div id="game-over" aria-live="polite"></div>
   <div class="difficulty-area">
     <div class="book-link-wrap">
-      <a class="book-link" href="https://www.amazon.com/dp/B0GZ218GCF?ref=ppx_yo2ov_dt_b_fed_asin_title" target="_blank" rel="noopener noreferrer">Get The Official Book NOW!</a>
+      <a id="official-book-link" class="book-link" href="https://www.amazon.com/dp/B0GZ218GCF?ref=ppx_yo2ov_dt_b_fed_asin_title" target="_blank" rel="noopener noreferrer">Get The Official Book NOW!</a>
     </div>
     <!-- Difficulty Meter (hidden until game ends) -->
     <section id="difficulty-meter" class="difficulty hidden" aria-label="Difficulty rating">
@@ -1721,6 +1730,18 @@
     const difficultyBalls = Array.from(difficultyMeter.querySelectorAll(".ball"));
     const retryMessage = document.getElementById("retry-message");
 
+    // Google Analytics event tracking additions begin.
+    const officialBookLink = document.getElementById("official-book-link");
+
+    function trackGoogleAnalyticsEvent(eventName) {
+      gtag('event', eventName);
+    }
+
+    officialBookLink.addEventListener("click", () => {
+      trackGoogleAnalyticsEvent('book_click');
+    });
+    // Google Analytics event tracking additions end.
+
     let startTime;
     let timerInterval;
     let questionElements = [];
@@ -2445,6 +2466,8 @@
           if (totalTime <= 60) stars++;
           stars += correctCount;
           starsDiv.textContent = `⭐ Stars: ${stars}`;
+          // Google Analytics: record this successful puzzle completion once.
+          trackGoogleAnalyticsEvent('puzzle_completed');
           await insertCompletionOnWin(stars, totalTime);
           await syncStreakDisplay();
           showShareButtons();
@@ -2471,6 +2494,8 @@
     });
 
     function startGame() {
+      // Google Analytics: record this Start Game action once.
+      trackGoogleAnalyticsEvent('start_game');
       if (timerInterval) {
         clearInterval(timerInterval);
       }


### PR DESCRIPTION
### Motivation
- Install the provided Google global site tag to enable Ads/Analytics measurement and record three product conversion events without altering the UI or game logic.
- Ensure there is only one Google tag on the site and that event calls fire once per user action.

### Description
- Inserted the provided Google tag (`gtag.js`) immediately after the opening `<head>` with clear comment markers so it is the first head child and appears exactly once, preserving existing head content; change made in `index.html`.
- Added an `id="official-book-link"` to the existing book anchor to avoid changing its URL, text, styles, or behavior and wired a click listener that calls a small helper `trackGoogleAnalyticsEvent(eventName)` which invokes `gtag('event', ...)` for `book_click`; change made in `index.html`.
- Invoked `trackGoogleAnalyticsEvent('start_game')` at the start of the existing `startGame()` flow and `trackGoogleAnalyticsEvent('puzzle_completed')` in the successful-completion branch so `start_game` and `puzzle_completed` are recorded once per action; change made in `index.html`.
- All additions are commented with `// Google Analytics ... begin/end` or HTML comments so it’s clear where analytics code starts and ends, and no existing styling or functionality was altered; only `index.html` was modified.

### Testing
- Ran a Python HTML parse check which verified the Google tag is the first head child, appears once, and each requested `trackGoogleAnalyticsEvent('<name>')` call appears exactly once, and it passed.
- Extracted inline scripts and ran `node --check` to validate JavaScript syntax, which succeeded.
- Ran `git diff --check` to ensure no whitespace errors and committed the change; the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5eee0feda8832d9b94daf033b0d71a)