### PR TITLE
Add August 2–8 puzzle queue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1571,6 +1571,146 @@
       difficultyRating: 4.2,
       hintText: "5, 30, 964, 7128.",
       code: [6, 1, 4, 8, 7]
+    },
+    {
+      releaseDate: "2026-08-02",
+      questions: [
+        "Trivia: How many distinct digits are used in binary?",
+        "Algebra: Solve x/2 + 5 = 42",
+        "Exponent/Subtraction: Compute 31² − 55",
+        "Place value: Write 1 thousand, 8 hundreds, 5 tens, and 3 ones as a number",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [7, 4],
+        [9, 0, 6],
+        [1, 8, 5, 3],
+        [9, 4, 6, 7, 3]
+      ],
+      difficultyRating: 3.7,
+      hintText: "2, 74, 906, 1853.",
+      code: [9, 4, 6, 7, 3]
+    },
+    {
+      releaseDate: "2026-08-03",
+      questions: [
+        "Tally marks are often counted in sets of what?",
+        "Find the y-intercept point (x,y): 5x + 3y = 24",
+        "Subtraction: Compute 400 − 83",
+        "Algebra: Evaluate 7n − 6 when n = 900",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [0, 8],
+        [3, 1, 7],
+        [6, 2, 9, 4],
+        [0, 2, 6, 4, 7]
+      ],
+      difficultyRating: 3.5,
+      hintText: "5, 08, 317, 6294.",
+      code: [0, 2, 6, 4, 7]
+    },
+    {
+      releaseDate: "2026-08-04",
+      questions: [
+        "Science: On the pH scale, what number is neutral?",
+        "Time: One minute is this many seconds?",
+        "Exponent/Subtraction: Compute 8³ − 160",
+        "Division: 16,388 ÷ 2",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [7],
+        [6, 0],
+        [3, 5, 2],
+        [8, 1, 9, 4],
+        [8, 0, 9, 4, 5]
+      ],
+      difficultyRating: 3.2,
+      hintText: "7, 60, 352, 8194.",
+      code: [8, 0, 9, 4, 5]
+    },
+    {
+      releaseDate: "2026-08-05",
+      questions: [
+        "Algebra: What is the multiplicative identity?",
+        "Number theory: Find the least common multiple of 29 and 2",
+        "Biology: How many bones are usually in an adult human skeleton?",
+        "Multiplication: 4687 × 2",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [5, 8],
+        [2, 0, 6],
+        [9, 3, 7, 4],
+        [5, 8, 7, 0, 4]
+      ],
+      difficultyRating: 4.4,
+      hintText: "1, 58, 206, 9374.",
+      code: [5, 8, 7, 0, 4]
+    },
+    {
+      releaseDate: "2026-08-06",
+      questions: [
+        "Graphing: How many quadrants are on an x-y coordinate plane?",
+        "Multiplication: Compute 46 × 2",
+        "Solve the system (a,b,c): a − 2 = b, 3a = 4b, c = 0",
+        "A library had 2,000 books and donated 427. How many books remain?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [9, 2],
+        [8, 6, 0],
+        [1, 5, 7, 3],
+        [4, 5, 0, 3, 6]
+      ],
+      difficultyRating: 3.1,
+      hintText: "4, 92, 860, 1573.",
+      code: [4, 5, 0, 3, 6]
+    },
+    {
+      releaseDate: "2026-08-07",
+      questions: [
+        "Algebra: How many real solutions does |x| = −3 have?",
+        "Evaluate: 7n + 10 when n = 9",
+        "Multiplication: Compute 197 × 3",
+        "Place value: Write 2 thousands, 8 hundreds, 4 tens, and 6 ones as a number",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [0],
+        [7, 3],
+        [5, 9, 1],
+        [2, 8, 4, 6],
+        [8, 9, 1, 6, 7]
+      ],
+      difficultyRating: 3.8,
+      hintText: "0, 73, 591, 2846.",
+      code: [8, 9, 1, 6, 7]
+    },
+    {
+      releaseDate: "2026-08-08",
+      questions: [
+        "Chemistry: How many electrons are in a neutral carbon atom?",
+        "Time: How many years are in a decade?",
+        "Exponent/Division: Compute 65² ÷ 5",
+        "Money: The total is $10.73 and you pay with a $50 bill. What is the change? (Enter cents without a decimal.)",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [1, 0],
+        [8, 4, 5],
+        [3, 9, 2, 7],
+        [2, 4, 5, 7, 8]
+      ],
+      difficultyRating: 4.1,
+      hintText: "6, 10, 845, 3927.",
+      code: [2, 4, 5, 7, 8]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Queue the next seven daily puzzles (August 2–8, 2026) so the game has prepared content for those release dates.
- Make minor prompt clarifications to avoid ambiguous answers and fix a malformed quotation mark in one prompt.

### Description
- Inserted seven new puzzle objects into the `puzzleSchedule` in `index.html` for `2026-08-02` through `2026-08-08`, each with `questions`, `correctAnswers`, `hintText`, `difficultyRating`, and `code` fields.
- Clarified the August 8 chemistry prompt to reference a neutral carbon atom and specified the money answer should be entered in cents without a decimal, and corrected a bad closing quote in the exponent/division prompt.
- Ensured each new puzzle’s final `correctAnswers[4]` matches its `code` array and that the schedule remains chronological and unique by `releaseDate`.

### Testing
- Parsed the `puzzleSchedule` with Node.js and validated that each of the 7 additions contains five questions, five answer sets, a five-digit `code`, and that `correctAnswers[4]` equals `code` (all checks passed).
- Ran JavaScript syntax checks (`node --check` on the schedule block) and programmatic arithmetic validations for supplied answers (all assertions passed).
- Ran `git diff --check` and other repository checks to confirm no whitespace/syntax issues; all checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a60fd8a7a08832d8954c2e8a593b8d1)