### PR TITLE
Add August 9–15 puzzle queue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1711,6 +1711,146 @@
       difficultyRating: 4.1,
       hintText: "6, 10, 845, 3927.",
       code: [2, 4, 5, 7, 8]
+    },
+    {
+      releaseDate: "2026-08-09",
+      questions: [
+        "Chemistry: What is nitrogen's atomic number?",
+        "Temperature: Water freezes at how many degrees Fahrenheit?",
+        "Subtraction: Compute 1000 − 195",
+        "Algebra: Evaluate 4n + 169 when n = 1000",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [7],
+        [3, 2],
+        [8, 0, 5],
+        [4, 1, 6, 9],
+        [3, 0, 5, 6, 9]
+      ],
+      difficultyRating: 3.6,
+      hintText: "7, 32, 805, 4169.",
+      code: [3, 0, 5, 6, 9]
+    },
+    {
+      releaseDate: "2026-08-10",
+      questions: [
+        "Geometry: How many sides does a quadrilateral have?",
+        "Compute: 17 × 4",
+        "Time: How many hours are in 8 days?",
+        "Percent: 75% of 4100",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [4],
+        [6, 8],
+        [1, 9, 2],
+        [3, 0, 7, 5],
+        [6, 9, 8, 5, 2]
+      ],
+      difficultyRating: 3.4,
+      hintText: "4, 68, 192, 3075.",
+      code: [6, 9, 8, 5, 2]
+    },
+    {
+      releaseDate: "2026-08-11",
+      questions: [
+        "Exponent: Compute 3²",
+        "Measurement: How many pounds are in one stone?",
+        "Multiplication: Compute 121 × 6",
+        "Place value: Write 3 thousands, 8 hundreds, 0 tens, and 5 ones as a number",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [9],
+        [1, 4],
+        [7, 2, 6],
+        [3, 8, 0, 5],
+        [3, 4, 6, 5, 9]
+      ],
+      difficultyRating: 3.1,
+      hintText: "9, 14, 726, 3805.",
+      code: [3, 4, 6, 5, 9]
+    },
+    {
+      releaseDate: "2026-08-12",
+      questions: [
+        "Number theory: How many positive factors does 16 have?",
+        "Exponent: Compute 3². Enter as two digits.",
+        "Multiplication: Compute 71 × 4",
+        "A store had 8000 items and sold 684. How many remain?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [0, 9],
+        [2, 8, 4],
+        [7, 3, 1, 6],
+        [0, 8, 4, 1, 6]
+      ],
+      difficultyRating: 3.7,
+      hintText: "5, 09, 284, 7316.",
+      code: [0, 8, 4, 1, 6]
+    },
+    {
+      releaseDate: "2026-08-13",
+      questions: [
+        "Algebra: How many solutions does 2x = 10 have?",
+        "Subtraction: Compute 60 − 3",
+        "Multiplication: Compute 213 × 3",
+        "Division: Compute 9632 ÷ 4",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [5, 7],
+        [6, 3, 9],
+        [2, 4, 0, 8],
+        [5, 3, 1, 8, 0]
+      ],
+      difficultyRating: 2.9,
+      hintText: "1, 57, 639, 2408.",
+      code: [5, 3, 1, 8, 0]
+    },
+    {
+      releaseDate: "2026-08-14",
+      questions: [
+        "Music: How many notes are in an octave?",
+        "Cards: How many red cards are in a standard deck?",
+        "Subtraction: Compute 1000 − 497",
+        "Algebra: Evaluate 9n³ + 7n² + 4n + 1 when n = 10",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [2, 6],
+        [5, 0, 3],
+        [9, 7, 4, 1],
+        [3, 0, 4, 1, 2]
+      ],
+      difficultyRating: 3.3,
+      hintText: "8, 26, 503, 9741.",
+      code: [3, 0, 4, 1, 2]
+    },
+    {
+      releaseDate: "2026-08-15",
+      questions: [
+        "Algebra: Solve for x, 5x + 9 = 9",
+        "Geometry: How many degrees are in half of a right angle?",
+        "Addition: Compute 303 + 88 + 327",
+        "Multiplication: Compute 203 × 31",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [0],
+        [4, 5],
+        [7, 1, 8],
+        [6, 2, 9, 3],
+        [4, 8, 9, 3, 1]
+      ],
+      difficultyRating: 3.8,
+      hintText: "0, 45, 718, 6293.",
+      code: [4, 8, 9, 3, 1]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Add the next week of daily puzzles to the in-app schedule so each day from 2026-08-09 through 2026-08-15 has questions, answers, hints, codes, and difficulty ratings.
- Fix small content issues discovered while preparing the week (missing final-code prompt and an incorrect question category label).

### Description
- Inserted seven new puzzle objects into `puzzleSchedule` in `index.html` for release dates `2026-08-09` through `2026-08-15`, each containing `questions`, `correctAnswers`, `difficultyRating`, `hintText`, and `code` fields.
- Restored the missing "Enter the final 5-digit code" prompt for the 2026-08-13 puzzle.
- Corrected the August 15 third-question label from "Subtraction" to "Addition" and adjusted the wording to `Addition: Compute 303 + 88 + 327`.
- Ensured answer arrays align with expected digit widths and that each puzzle's `code` matches the fifth answer array.

### Testing
- Ran `git diff --check` to ensure there are no obvious whitespace or diff issues, which succeeded.
- Executed a Node validation script that parsed `puzzleSchedule` and confirmed there are 7 new puzzles, each has 5 questions and 5 answer entries, each answer has the expected length, and each puzzle's `code` matches its final answer, which reported success.
- Verified the file diff shows the intended 140-line insertion into `index.html` and no other unexpected changes, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6b8db6fab4832d8ad445b2608e0ac6)