### PR TITLE
Increase puzzle completion streak query limit

### DIFF
--- a/index.html
+++ b/index.html
@@ -2158,7 +2158,7 @@
         .select("puzzle_date")
         .eq("user_id", user.id)
         .order("puzzle_date", { ascending: false })
-        .limit(60);
+        .limit(1000);
       if (error) {
         console.warn("Supabase completion read failed:", error);
         return [];


### PR DESCRIPTION
### Motivation
- Prevent streak calculations from being artificially capped by a 60-row fetch by reading a larger recent history while keeping all completion rows retained and behavior unchanged.

### Description
- In `fetchUserCompletions`, changed the Supabase read from `.limit(60)` to `.limit(1000)` while preserving `.order("puzzle_date", { ascending: false })`, and made no other changes to insertion, authentication, puzzle logic, or difficulty-rating behavior.

### Testing
- Ran an automated assertion that `.limit(60)` was removed and `.limit(1000)` is present, ran a Node.js VM test of `computeStreakFromDates` to verify yesterday-anchored current streak behavior when today is unsolved, and ran `git diff --check`; all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a721e6df1f4832db35efc353b381f59)