### PR TITLE
Add August 16–22, 2026 puzzle week

### DIFF
--- a/index.html
+++ b/index.html
@@ -1851,6 +1851,146 @@
       difficultyRating: 3.8,
       hintText: "0, 45, 718, 6293.",
       code: [4, 8, 9, 3, 1]
+    },
+    {
+      releaseDate: "2026-08-16",
+      questions: [
+        "Computer science: How many possible values can a single bit have?",
+        "Addition: 6 + 7 + 13 + 7 + 6",
+        "Multiplication: Compute 23 × 37",
+        "A fundraiser has a goal of $8,000 and has raised $936. How many dollars are still needed?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [2],
+        [3, 9],
+        [8, 5, 1],
+        [7, 0, 6, 4],
+        [2, 9, 1, 7, 4]
+      ],
+      difficultyRating: 3.5,
+      hintText: "2, 39, 851, 7064.",
+      code: [2, 9, 1, 7, 4]
+    },
+    {
+      releaseDate: "2026-08-17",
+      questions: [
+        "Algebra: the slope of y = 6x +1",
+        "Geometry: What is each exterior angle of a regular 20-gon?",
+        "Combinatorics: Compute 6!",
+        "Algebra: Evaluate 5n − 47 when n = 1000",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [6],
+        [1, 8],
+        [7, 2, 0],
+        [4, 9, 5, 3],
+        [4, 8, 0, 1, 3]
+      ],
+      difficultyRating: 4.0,
+      hintText: "6, 18, 720, 4953.",
+      code: [4, 8, 0, 1, 3]
+    },
+    {
+      releaseDate: "2026-08-18",
+      questions: [
+        "Baseball: How many innings are in a regulation game?",
+        "Money: How many cents are in a quarter?",
+        "Solve (a,b,c): 2b +1 = c, c + a = 7, a = 0",
+        "Place value: Write 8 thousands, 1 hundred, 6 tens, and 4 ones as a number",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [9],
+        [2, 5],
+        [0, 3, 7],
+        [8, 1, 6, 4],
+        [9, 1, 7, 4, 0]
+      ],
+      difficultyRating: 3.1,
+      hintText: "9, 25, 037, 8164.",
+      code: [9, 1, 7, 4, 0]
+    },
+    {
+      releaseDate: "2026-08-19",
+      questions: [
+        "Algebra: How many solutions does 2x + 1 = 3 have?",
+        "Biology: How many chromosomes are normally in a human body cell?",
+        "Subtraction: Compute 1000 − 95",
+        "Exponent/Addition: Compute 7³ + 2494",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [1],
+        [4, 6],
+        [9, 0, 5],
+        [2, 8, 3, 7],
+        [0, 6, 3, 7, 4]
+      ],
+      difficultyRating: 4.1,
+      hintText: "1, 46, 905, 2837.",
+      code: [0, 6, 3, 7, 4]
+    },
+    {
+      releaseDate: "2026-08-20",
+      questions: [
+        "Counting: How many fingers are shown in a high five?",
+        "Algebra: Find the y-intercept (x,y) of -5x + 3y = 6.",
+        "Multiplication: Compute 19 × 36",
+        "Exponent/Addition: Compute 13² + 1228",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [5],
+        [0, 2],
+        [6, 8, 4],
+        [1, 3, 9, 7],
+        [1, 8, 0, 7, 4]
+      ],
+      difficultyRating: 3.3,
+      hintText: "5, 02, 684, 1397.",
+      code: [1, 8, 0, 7, 4]
+    },
+    {
+      releaseDate: "2026-08-21",
+      questions: [
+        "Biology: How many legs does an arachnid have?",
+        "Roman numerals: Convert LXXIV to a decimal number",
+        "Subtraction: Compute 200 − 37",
+        "A 10,000-meter race has 795 meters left. How many meters have been completed?",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [8],
+        [7, 4],
+        [1, 6, 3],
+        [9, 2, 0, 5],
+        [8, 6, 7, 5, 3]
+      ],
+      difficultyRating: 3.4,
+      hintText: "8, 74, 163, 9205.",
+      code: [8, 6, 7, 5, 3]
+    },
+    {
+      releaseDate: "2026-08-22",
+      questions: [
+        "Algebra: Over the real numbers, how many solutions does |x| = -4 have?",
+        "Pittsburgh trivia: Heinz is famous for how many varieties?",
+        "Money: 2 dollars, 4 dimes and 9 pennies is how much cents?",
+        "Addition: Compute 4902 + 1140 + 141",
+        "Enter the final 5-digit code"
+      ],
+      correctAnswers: [
+        [0],
+        [5, 7],
+        [2, 4, 9],
+        [6, 1, 8, 3],
+        [8, 4, 9, 3, 0]
+      ],
+      difficultyRating: 3.6,
+      hintText: "0, 57, 249, 6183.",
+      code: [8, 4, 9, 3, 0]
     }
    ].sort((a, b) => a.releaseDate.localeCompare(b.releaseDate));
 


### PR DESCRIPTION
### Motivation
- Publish the next week of daily puzzles so they appear in the app schedule for August 16–22, 2026.
- Include full puzzle metadata (questions, `correctAnswers`, `hintText`, `difficultyRating`, and final `code`) so the UI and validation logic can use them.
- Fix a small wording issue discovered while inserting the entries (corrected “acranid” → “arachnid”).

### Description
- Inserted seven new puzzle objects into the `puzzleSchedule` array in `index.html` for release dates `2026-08-16` through `2026-08-22`, each containing `questions`, `correctAnswers`, `hintText`, `difficultyRating`, and `code`.
- Ensured the schedule remains sorted via the existing `.sort((a, b) => a.releaseDate.localeCompare(b.releaseDate))` usage.
- Fixed the August 21 question wording from “acranid” to `arachnid` while adding the supplied puzzle content.
- Committed the changes with message "Add August 16 puzzle week".

### Testing
- Ran a script that extracts the in-file `puzzleSchedule` block and validated it with `node`/`vm` to assert no duplicate dates and that each puzzle has 5 questions, 5 `correctAnswers` entries, and a 5-digit `code`; this validation succeeded and reported the new dates present.
- Executed `node --check /tmp/puzzleSchedule.js` to syntax-check the extracted schedule; this check succeeded.
- Attempted `node --check index.html` which is not applicable to `.html` files and therefore failed, so the above schedule-extraction checks were used instead and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a739c34fe2c832d9f9087a7126dd509)