### PR TITLE
Render yellow feedback as a centered circle inside the tile

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,8 +170,9 @@
       transform: scale(1.05);
     }
     .cell.yellow { 
-      background: #f39c12; 
-      border-color: #d35400;
+      background-color: #222;
+      background-image: radial-gradient(circle at center, #f39c12 0 35%, transparent 36%);
+      border-color: #444;
       transform: scale(1.05);
     }
     .cell.gray { 
@@ -635,9 +636,10 @@
       color: #0b2f16;
     }
     body.light-mode .cell.yellow {
-      background: #ffd54f;
-      border-color: #ffb300;
-      color: #5a4100;
+      background-color: #ffffff;
+      background-image: radial-gradient(circle at center, #ffd54f 0 35%, transparent 36%);
+      border-color: #c3c8d0;
+      color: #111;
     }
     body.light-mode .cell.gray {
       background: #cfd8dc;


### PR DESCRIPTION
### Motivation
- Present yellow/hint feedback as a centered yellow circle inside the existing square tile so the visual hint is less dominant while preserving all game logic and green/gray feedback styles.

### Description
- Replace the previous yellow fill by updating the `.cell.yellow` and `body.light-mode .cell.yellow` rules to use a neutral square background plus a centered `radial-gradient` that renders a ~70% diameter yellow circle, leaving `.cell.green` and `.cell.gray` styles and all JS logic untouched.

### Testing
- Ran an automated Python assertion script that checked the dark/light `.cell.yellow` rules contain the radial gradients and neutral backgrounds and that `.cell.green`, `.cell.gray`, and the JS feedback-class assignment remain present, and all assertions passed; no headless browser was available for pixel screenshots.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d2775cfd0832d9ef9df1c7c4e62cd)