### PR TITLE
Enlarge yellow hint circles to inscribe feedback cells

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,7 +171,7 @@
     }
     .cell.yellow { 
       background-color: #222;
-      background-image: radial-gradient(circle at center, #f39c12 0 35%, transparent 36%);
+      background-image: radial-gradient(circle closest-side at center, #f39c12 0 100%, transparent 100%);
       border-color: #444;
       transform: scale(1.05);
     }
@@ -637,7 +637,7 @@
     }
     body.light-mode .cell.yellow {
       background-color: #ffffff;
-      background-image: radial-gradient(circle at center, #ffd54f 0 35%, transparent 36%);
+      background-image: radial-gradient(circle closest-side at center, #ffd54f 0 100%, transparent 100%);
       border-color: #c3c8d0;
       color: #111;
     }


### PR DESCRIPTION
### Motivation
- Make the yellow hint feedback render as a full inscribed circle inside each `.cell` so hint dots are larger and centered in both dark and light modes.

### Description
- Update the `.cell.yellow` CSS in dark and light modes to use `radial-gradient(circle closest-side at center, <color> 0 100%, transparent 100%)`, replacing the previous smaller-stop gradient so the yellow circle fills the cell.

### Testing
- Parsed `index.html` with `HTMLParser().feed(Path('index.html').read_text())` and ran `git diff --check`, `git diff HEAD^ --check`, and `git status --porcelain`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d2a261ca4832d9abb72d376cb0060)